### PR TITLE
use fqdn

### DIFF
--- a/webpack/server-urls-dev.json
+++ b/webpack/server-urls-dev.json
@@ -1,6 +1,6 @@
 {
     "CELL_VIEWER_URL": "'http://localhost:9020/imageviewer/'",
     "BASE_API_URL": "'data'",
-    "THUMBNAIL_BASE_URL": "'http://dev-aics-dtp-001/cellviewer-1-4-0/Cell-Viewer_Thumbnails'",
-    "DOWNLOAD_URL_PREFIX":"'https://files.allencell.org/api/2.0/file/download?collection=cellviewer-1-4'"
+    "THUMBNAIL_BASE_URL": "'http://dev-aics-dtp-001.corp.alleninstitute.org/cellviewer-1-4-0/Cell-Viewer_Thumbnails'",
+    "DOWNLOAD_URL_PREFIX": "'https://files.allencell.org/api/2.0/file/download?collection=cellviewer-1-4'"
 }

--- a/webpack/server-urls-staging.json
+++ b/webpack/server-urls-staging.json
@@ -1,6 +1,6 @@
 {
     "CELL_VIEWER_URL": "'/website-3d-cell-viewer/imageviewer/'",
-    "BASE_API_URL": "'http://dev-aics-dtp-001/cellviewer-1-4-0/'",
-    "THUMBNAIL_BASE_URL": "'http://dev-aics-dtp-001/cellviewer-1-4-0/Cell-Viewer_Thumbnails'",
-    "DOWNLOAD_URL_PREFIX":"'https://files.allencell.org/api/2.0/file/download?collection=cellviewer-1-4'"
+    "BASE_API_URL": "'http://dev-aics-dtp-001.corp.alleninstute.org/cellviewer-1-4-0/'",
+    "THUMBNAIL_BASE_URL": "'http://dev-aics-dtp-001.corp.alleninstute.org/cellviewer-1-4-0/Cell-Viewer_Thumbnails'",
+    "DOWNLOAD_URL_PREFIX": "'https://files.allencell.org/api/2.0/file/download?collection=cellviewer-1-4'"
 }


### PR DESCRIPTION
When connecting to the animated-cell dev server over VPN, some requests were failing because config settings were not using fully qualified domain names.
Using the FQDN fixes the issue.
