### PR TITLE
Feature/jsondataformat updates

### DIFF
--- a/src/state/image-dataset/json-dataset/index.ts
+++ b/src/state/image-dataset/json-dataset/index.ts
@@ -141,11 +141,6 @@ class JsonRequest implements ImageDataset {
     };
 
     public getMeasuredFeatureDefs = () => {
-        if (!this.datasetInfo) {
-            // or reject?
-            return Promise.resolve([]);
-        }
-
         if (this.featureDefinitions && this.featureDefinitions.length > 0) {
             return Promise.resolve(this.featureDefinitions);
         }
@@ -173,7 +168,7 @@ class JsonRequest implements ImageDataset {
         }
 
         // if display order is not provided, then use data order as display order.
-        if (this.datasetInfo?.featuresDisplayOrder.length === 0) {
+        if (this.datasetInfo.featuresDisplayOrder.length === 0) {
             this.datasetInfo.featuresDisplayOrder = this.datasetInfo.featuresDataOrder.slice();
         }
         const dataMappedByMeasuredFeatures = this.datasetInfo.featuresDisplayOrder.reduce(


### PR DESCRIPTION
Problem
=======
Make sure the json data format can load with the latest data sets (cellsystems-2021-fish and live).  Also make sure that it accounts for featureDisplayOrder

Solution
========
Add an interface with the full Dataset type information.
Implement featureDisplayOrder the same way it is done in the firebase implementation.

This is mostly a maintenance update.  The only noticeable change should be to observe that features display order is respected.
Testable only by building with the USE_JSON_DATASET flag.