### PR TITLE
Feature/new feature def location

### DIFF
--- a/src/state/image-dataset/firebase/index.ts
+++ b/src/state/image-dataset/firebase/index.ts
@@ -163,7 +163,6 @@ class FirebaseRequest implements ImageDataset {
         const listOfFeatureKeys = [...this.featuresDisplayOrder];
         const dataset: MeasuredFeatureDef[] = [];
         await this.requestSetOfFeatureDefs(listOfFeatureKeys, dataset);
-        console.log(dataset)
         return dataset;
     };
 


### PR DESCRIPTION
Problem
=======
Feature defs have been moved to a per dataset collection in the database: [see change here ](https://github.com/allen-cell-animated/cell-feature-data/pull/13/commits/4a03e64712c804ed7e06620bf480a6b198b52b18#diff-378fcd4d033b2801df1a53411c1a67cb1fc2972df29c17f2c941d054c8d2aaf2) and [PR here ](https://github.com/allen-cell-animated/cell-feature-data/pull/15)
Only 10 feature defs were being requested from the database. 

Solution
========
Use the featureDefsPath in the manifest to request the feature defs, 
Request feature defs in batches. 

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. npm run start:dev-db
2. load one of the new datasets
1. verify that there are more than 10 features in the dropdowns


