### PR TITLE
Fix/gallery thumbnail not showing with Cellsystems dataset

### DIFF
--- a/src/containers/ThumbnailGallery/selectors.ts
+++ b/src/containers/ThumbnailGallery/selectors.ts
@@ -86,10 +86,10 @@ export const getThumbnails = createSelector(
             if (cellIndex < 0) {
                 return {} as Thumbnail;
             }
-            const mitoticKey = mitoticKeysArray[cellIndex];
 
             let mitoticStage = "";
-            if (mitoticStageNames[mitoticKey]) {
+            if (!isEmpty(mitoticStageNames) && mitoticKeysArray.length) {
+                const mitoticKey = mitoticKeysArray[cellIndex];
                 mitoticStage = mitoticStageNames[mitoticKey].name;
             }
 


### PR DESCRIPTION
Problem
=======
Resolves: [clicking a plotted cell does not show a gallery thumbnail](https://aicsjira.corp.alleninstitute.org/browse/CFE-55) when viewing the new FISH data

Solution
========
Turns out that the new datasets' `CellId` values starting with a letter was causing the problem. The current `getThumbnails` selector checks if `CellId` is a number or not, and if not, it just returns an empty object as the thumbnail. So I removed that check.

Also, `mitoticStageNames[mitoticKey]` is undefined in the new dataset, so that also causes an error. In fact `mitoticKeysArray` and `mitoticStageNames` are both empty. I'm not sure what the real best way to deal with this is, but I just set `mitoticStage` as an empty string for now if it's undefined.

## NOTE!
The only real change in this PR is in [this commit](https://github.com/allen-cell-animated/cell-feature-explorer/commit/f7a3c19fa36481271d15683ca69835c9bd17224e) and later [this commit](https://github.com/allen-cell-animated/cell-feature-explorer/pull/53/commits/c65b629e67cb55163be9757a2ef9133dff55d34e). But everything else in the selector was indented funny so I fixed that too.

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Pull this branch and `npm run start:dev-db`
2. Open the FISH dataset and click on a point on the main plot. Thumbnail image appears in the gallery panel on the right.
3. Quit the dev server and run `npm start`
4. Open any of the variance paper datasets and verify that the thumbnails on those still work as before.

