### PR TITLE
Fix/downloader links for Cellsystems dataset

### DIFF
--- a/src/state/test/util.test.ts
+++ b/src/state/test/util.test.ts
@@ -8,6 +8,8 @@ import {
     enableBatching,
     makeConstant,
     makeReducer,
+    convertFullFieldIdToDownloadId,
+    convertSingleImageIdToDownloadId,
 } from "../util";
 
 describe("state utilities", () => {
@@ -144,6 +146,38 @@ describe("state utilities", () => {
             const result = batchingReducer(initialState, enableBeans);
             expect(result).to.deep.equal(reducer(initialState, enableBeans));
             expect(result).to.deep.equal(expectedState);
+        });
+    });
+});
+
+describe("general utilities", () => {
+    describe("convertFullFieldIdToDownloadId", () => {
+        it("attaches prefix to an ID if it is a number of type number", () => {
+            const id = 12345;
+            const downloadId = convertFullFieldIdToDownloadId(id);
+            expect(downloadId).to.equal("F12345");
+        });
+        it("attaches prefix to an ID if it is a number of type string", () => {
+            const id = "12345";
+            const downloadId = convertFullFieldIdToDownloadId(id);
+            expect(downloadId).to.equal("F12345");
+        });
+        it("does not attach prefix to an ID if it is not a number", () => {
+            const id = "F12345";
+            const downloadId = convertFullFieldIdToDownloadId(id);
+            expect(downloadId).to.equal("F12345");
+        });
+    });
+    describe("convertSingleImageIdToDownloadId", () => {
+        it("attaches prefix to an ID if it is a number", () => {
+            const id = "12345";
+            const downloadId = convertSingleImageIdToDownloadId(id);
+            expect(downloadId).to.equal("C12345");
+        });
+        it("does not attach prefix to an ID if it is not a number", () => {
+            const id = "C12345";
+            const downloadId = convertSingleImageIdToDownloadId(id);
+            expect(downloadId).to.equal("C12345");
         });
     });
 });

--- a/src/state/util.ts
+++ b/src/state/util.ts
@@ -58,11 +58,21 @@ export function getFileInfoDatumFromCellId(fileInfoArray: FileInfo[], cellId: st
 }
 
 export function convertFullFieldIdToDownloadId(id: number | string): string {
-    return `F${id}`;
+    // Only attach prefix if id is a number (not already prefixed with a letter)
+    if (!isNaN(Number(id))) {
+        return `F${id}`;
+    } else {
+        return id as string;
+    }
 }
 
 export function convertSingleImageIdToDownloadId(id: string): string {
-    return `C${id}`;
+    // Only attach prefix if id is a number (not already prefixed with a letter)
+    if (!isNaN(Number(id))) {
+        return `C${id}`;
+    } else {
+        return id;
+    }
 }
 
 export function formatDownloadOfSingleImage(root: string, id: string): string {


### PR DESCRIPTION
Problem
=======
Resolves: [downloader links broken due to naming error](https://aicsjira.corp.alleninstitute.org/browse/CFE-64
)

Solution
========
* @meganrm changed `cellsystems-2021-fish.1` in the URL query string to `cellsystems-2021-fish_1` (in Firebase?)
* I implemented a quick fix to not prepend an extra prefix like F or C to the id if the id is a non-number (already has prefix).

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)
* This change requires updated or new tests

Steps to Verify:
----------------
1. `npm run start:dev-db`
2. Open a FISH dataset
3. Open the gallery panel
4. Click the download icon for the pre-selected cell (or any cell you add to the gallery) and select "Full field image" (The "Segmented cell" download still won't work because that file doesn't exist, I think that's [this issue](https://aicsjira.corp.alleninstitute.org/browse/CFE-66)?)
5. The downloaded file should be a non-empty tar file containing data.
