### PR TITLE
Fix/Segmented Cell download link visible in gallery for Cell Systems data

### DIFF
--- a/src/containers/ThumbnailGallery/selectors.ts
+++ b/src/containers/ThumbnailGallery/selectors.ts
@@ -96,18 +96,22 @@ export const getThumbnails = createSelector(
             }
             
             let downloadHref = "";
-            if (fileInfoForCell[VOLUME_VIEWER_PATH] && fileInfoForCell[FOV_VOLUME_VIEWER_PATH]) {
+            if (fileInfoForCell[VOLUME_VIEWER_PATH]) {
                 downloadHref = formatDownloadOfSingleImage(
                     downloadRoot,
                     convertSingleImageIdToDownloadId(cellID)
                 );
             }
 
-            const fovId = fileInfoForCell[FOV_ID_KEY];    
-            const fullFieldDownloadHref = formatDownloadOfSingleImage(
-                downloadRoot,
-                convertFullFieldIdToDownloadId(fovId)
-            );
+            const fovId = fileInfoForCell[FOV_ID_KEY];
+            let fullFieldDownloadHref = "";
+            if (fileInfoForCell[FOV_VOLUME_VIEWER_PATH]) {
+                fullFieldDownloadHref = formatDownloadOfSingleImage(
+                    downloadRoot,
+                    convertFullFieldIdToDownloadId(fovId)
+                );
+            }
+            
             const thumbnailSrc = formatThumbnailSrc(thumbnailRoot, fileInfoForCell);
             return {
                 cellID,


### PR DESCRIPTION
Problem
=======
Resolves: [Gallery download button shows Segmented Cell option for FISH data](https://aicsjira.corp.alleninstitute.org/browse/CFE-69)

Solution
========
Set `downloadHref` to an empty string if either `volumeViewerPath` or `fovVolumeViewerPath` (or both) is missing. The gallery card component already handles an empty string value for `downloadHref` appropriately (doesn't show an option to download Segmented Cell image).

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. `npm start`
2. Open a Cell Systems dataset
3. Open gallery panel
4. Click on the download icon for a cell. There should only be 1 option available (Full Field Image).
5. Go back to the CFE landing page and open a variance paper dataset
6. Open gallery panel
7. Click on the download icon for a cell. There should be 2 download options like before.

Screenshots (optional):
-----------------------
![image](https://user-images.githubusercontent.com/12690133/126839958-539e55b0-9625-4073-80d3-a6ed5177f931.png)
