### PR TITLE
make channel settings dataset dependent

### DIFF
--- a/src/components/CellViewer/index.tsx
+++ b/src/components/CellViewer/index.tsx
@@ -7,8 +7,6 @@ import {
     OBS_DNA_NAMES,
     OBS_MEMBRANE_NAMES,
     OBS_STRUCTURE_NAMES,
-    VARIANCE_DATASET_CHANNEL_NAME_MAPPINGS,
-    VARIANCE_DATASET_CHANNEL_GROUPINGS,
 } from "../../constants/index";
 import { VolumeViewerProps } from "../../containers/Cfe/selectors";
 
@@ -52,8 +50,8 @@ const CellViewer: React.FunctionComponent<VolumeViewerProps> = (props) => {
                 // TODO see if channelNameClean is redundant with channelNameMapping
                 channelNameClean={standardizeNames}
                 appHeight="90vh"
-                channelNameMapping={VARIANCE_DATASET_CHANNEL_NAME_MAPPINGS}
-                groupToChannelNameMap={VARIANCE_DATASET_CHANNEL_GROUPINGS}
+                channelNameMapping={props.channelNameMapping}
+                groupToChannelNameMap={props.groupToChannelNameMap}
             />
         </div>
     );

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -86,6 +86,7 @@ export const GENERAL_PLOT_SETTINGS = {
 };
 
 // TODO these are literally only used in one single place; maybe they could be moved into that one place?
+// TODO move these to the dataset data
 export const BRIGHT_FIELD_NAMES = ["Bright_100", "Bright_100X", "TL 100x", "Bright_2"];
 export const OBS_MEMBRANE_NAMES = ["CMDRP"];
 export const OBS_STRUCTURE_NAMES = ["EGFP", "mtagRFPT"];
@@ -112,3 +113,23 @@ export const VARIANCE_DATASET_CHANNEL_GROUPINGS = {
     "Segmentation channels": ["SEG_STRUCT", "SEG_Memb", "SEG_DNA"],
     "Contour channels": ["CON_Memb", "CON_DNA"],
 };
+
+export const NO_SETTINGS = {
+    channelNameMapping: "" as "", // type to empty string, not any string
+    groupToChannelNameMap: "" as "", // type to empty string, not any string
+};
+
+export const VIEWER_CHANNEL_SETTINGS: {
+           [key: string]:
+               | {
+                     channelNameMapping: "" | { test: RegExp; label: string }[];
+                     groupToChannelNameMap: "" | { [key: string]: string[] };
+                 }
+               | undefined;
+       } = {
+           // eslint-disable-next-line @typescript-eslint/camelcase
+           aics_hipsc: {
+               channelNameMapping: VARIANCE_DATASET_CHANNEL_NAME_MAPPINGS,
+               groupToChannelNameMap: VARIANCE_DATASET_CHANNEL_GROUPINGS,
+           },
+       };

--- a/src/containers/Cfe/selectors.ts
+++ b/src/containers/Cfe/selectors.ts
@@ -4,6 +4,7 @@ import { FileInfo } from "../../state/metadata/types";
 import {
     getDownloadRoot,
     getSelected3DCellFileInfo,
+    getSelectedDataset,
     getVolumeViewerDataRoot,
 } from "../../state/selection/selectors";
 import {
@@ -12,21 +13,28 @@ import {
     formatDownloadOfSingleImage,
 } from "../../state/util";
 
+import { VIEWER_CHANNEL_SETTINGS, NO_SETTINGS } from "../../constants";
+
 export interface VolumeViewerProps {
-    cellId: string,
-    baseUrl: string,
-    cellPath: string,
-    fovPath: string,
-    fovDownloadHref: string,
-    cellDownloadHref: string,
+    cellId: string;
+    baseUrl: string;
+    cellPath: string;
+    fovPath: string;
+    fovDownloadHref: string;
+    cellDownloadHref: string;
+    channelNameMapping?: { label: string; test: RegExp }[] | "";
+    groupToChannelNameMap?: { [key: string]: string[] } | "";
 }
 
 export const getPropsForVolumeViewer = createSelector(
-           [getSelected3DCellFileInfo, getVolumeViewerDataRoot, getDownloadRoot],
-           (fileInfo: FileInfo, dataRoot, downloadRoot): VolumeViewerProps => {
+           [getSelected3DCellFileInfo, getVolumeViewerDataRoot, getDownloadRoot, getSelectedDataset],
+           (fileInfo: FileInfo, dataRoot, downloadRoot, selectedDataset): VolumeViewerProps => {
                if (isEmpty(fileInfo)) {
                    return {} as VolumeViewerProps
                }
+               const selectedDatasetName = selectedDataset.split("_v")[0];
+               const channelSettings = VIEWER_CHANNEL_SETTINGS[selectedDatasetName] || {...NO_SETTINGS};
+               
                const formatPathForViewer = (path: string) => path.split("_atlas.json")[0];
 
                /**
@@ -55,6 +63,7 @@ export const getPropsForVolumeViewer = createSelector(
                        downloadRoot,
                        convertSingleImageIdToDownloadId(fileInfo ? fileInfo.CellId : "")
                    ),
+                   ...channelSettings,
                };
                return props;
            }


### PR DESCRIPTION
Problem
=======
The channel name mappings and groupings are specific to the variance dataset. [Link to story or ticket](https://aicsjira.corp.alleninstitute.org/browse/CFE-67)

Solution
========
I created a map that stores the optional channel name info. We want to push this up to the database I think, but this at least has the structure we'd want to have for combining the data in the selector.
Now the groupings only get sent in if it's one of the variance data sets. 

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)




Steps to Verify:
----------------
1. `npm start`
1.  load one of the new datasets
1. verify that the channels menu header is "channels"
1. load one of the old datasets
2. verify that the channels are grouped by obs, segmentation and contour

Screenshots (optional):
-----------------------
<img width="520" alt="Screen Shot 2021-07-23 at 4 55 24 PM" src="https://user-images.githubusercontent.com/5170636/126851287-515b79ce-1a8b-42e4-8019-a3d80543da44.png">
<img width="704" alt="Screen Shot 2021-07-23 at 5 00 12 PM" src="https://user-images.githubusercontent.com/5170636/126851290-87f44a33-5998-4bdb-9ee2-4148dc0fb993.png">



