### PR TITLE
Fix/overflowing checkbox labels in left panel

### DIFF
--- a/src/components/InteractiveRow/style.css
+++ b/src/components/InteractiveRow/style.css
@@ -20,12 +20,14 @@
 
 .label {
     flex: 1 66%;
+    max-width: 19em;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
 }
 
 .first-column {
+    display: flex;
     margin-top: 5px;
 }
 


### PR DESCRIPTION
Problem
=======
Overflowing text in left panel
![image](https://user-images.githubusercontent.com/12690133/126852995-0be35c37-ef06-410b-a6db-6b507cec2660.png)
Resolves: [max width for structure names](https://aicsjira.corp.alleninstitute.org/browse/CFE-58)

Solution
========
Flexbox magic..... 

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. `npm start` and verify that there is no more overflowing text like this anymore (in the new variance dataset)


Screenshots (optional):
-----------------------
![image](https://user-images.githubusercontent.com/12690133/126852939-49d09980-1af2-4334-a060-199eb1c1ff9c.png)