### PR TITLE
use image src from dataset if possible

### DIFF
--- a/src/components/DatasetCard/index.tsx
+++ b/src/components/DatasetCard/index.tsx
@@ -17,6 +17,7 @@ const DatasetCard: React.FunctionComponent<DatasetCardProps> = ({
     link,
     id,
     userData,
+    image,
 }: DatasetCardProps) => {
     const title = (
         <>
@@ -42,7 +43,7 @@ const DatasetCard: React.FunctionComponent<DatasetCardProps> = ({
                 <img
                     className={styles.staticThumbnail}
                     alt={`Snapshot of simulation for ${name}`}
-                    src={imageMapping[id as DatasetId]}
+                    src={image || imageMapping[id as DatasetId]}
                 />
             }
         >


### PR DESCRIPTION
Problem
=======
We want to show images for the new datasets

Solution
========
I added the images to the data https://github.com/allen-cell-animated/cell-feature-data/pull/19

## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. `npm start`
2. Should see images for all the cards

Screenshots (optional):
-----------------------
<img width="1106" alt="Screen Shot 2021-07-28 at 9 51 27 PM" src="https://user-images.githubusercontent.com/5170636/127442628-f3faf585-c591-421b-a13c-5b6f91a2a6e9.png">
