### PR TITLE
make sure feature defs are loaded early enough

### DIFF
--- a/src/state/image-dataset/json-dataset/index.ts
+++ b/src/state/image-dataset/json-dataset/index.ts
@@ -130,8 +130,7 @@ class JsonRequest implements ImageDataset {
                 return cellLines;
             })
             .then(() => {
-                this.featureDefsPromise = this.getMeasuredFeatureDefs();
-                return this.featureDefsPromise;
+                return this.getMeasuredFeatureDefs();
             })
             .then(() => {
                 this.dataPromise = this.getFeatureData();


### PR DESCRIPTION
Problem
=======
(Fixing an issue in json mode only.)
When loading a new dataset in json mode, some code was actually dependent on feature defs being loaded before the raw feature data.  This happens in the case where feature_data_order and feature_display_order are both unspecified (in which case we want to just adopt the order in feature_defs.json). It causes major failures during data loading.

Solution
========
Add some sync to guarantee that feature defs are loaded before the raw data.

## Type of change
* Bug fix (non-breaking change which fixes an issue)

Change summary:
---------------
The code that loads the actual data is now run in a `then` clause after fetching the feature defs.
Feature defs are now stored in the dataset instance as a Promise.

Steps to Verify:
----------------
The Isilon-stored new dataset variance_release has its feature_display_order and feature_data_order both empty arrays.  Confirm that this dataset loads:
http://dev-aics-dtp-001.corp.alleninstitute.org/cell-feature-explorer/dist/index.html?cellSelectedFor3D=232265&colorBy=Dataset&dataset=variance_review&plotByOnX=Cell%20surface%20area&plotByOnY=Cell%20volume&selectedPoint%5B0%5D=232265

(The volatile nature of this server and dataset means this link may not work some small amount of time after this PR is approved.)