### PR TITLE
use title instead of name

### DIFF
--- a/src/components/DatasetCard/index.tsx
+++ b/src/components/DatasetCard/index.tsx
@@ -10,7 +10,7 @@ interface DatasetCardProps extends DatasetMetaData {
 }
 
 const DatasetCard: React.FunctionComponent<DatasetCardProps> = ({
-    name,
+    title,
     version,
     description,
     handleSelectDataset,
@@ -19,13 +19,13 @@ const DatasetCard: React.FunctionComponent<DatasetCardProps> = ({
     userData,
     image,
 }: DatasetCardProps) => {
-    const title = (
+    const displayTitle = (
         <>
             <div>
                 {userData.isNew && <Tag color="purple">beta</Tag>}
-                {name}
+                {title}
             </div>
-            <span className={styles.version}>{version}</span>
+            <span className={styles.version}>v{version}</span>
             {userData.inReview && (
                 <>
                     <Divider type="vertical" /> (in review)
@@ -42,13 +42,13 @@ const DatasetCard: React.FunctionComponent<DatasetCardProps> = ({
             cover={
                 <img
                     className={styles.staticThumbnail}
-                    alt={`Snapshot of simulation for ${name}`}
+                    alt={`Snapshot of simulation for ${title}`}
                     src={image}
                 />
             }
         >
             <Meta
-                title={title}
+                title={displayTitle}
                 description={
                     <div
                         className="content"

--- a/src/constants/datasets.ts
+++ b/src/constants/datasets.ts
@@ -1,5 +1,6 @@
 export interface DatasetMetaData {
     name: string;
+    title: string;
     version: string;
     id: string;
     description: string;


### PR DESCRIPTION
Problem
=======
This updates the cards to use the new values. 
[Link to story or ticket](https://aicsjira.corp.alleninstitute.org/browse/CFE-59)

Solution
========
Use `title` instead of `name`

## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)


Steps to Verify:
----------------
1. `npm run start:dev-db`
2. Cards should look the same as they do now on staging/production
3. `npm start`
4. cards should be missing titles (the production database hasn't been updated yet)


