### PR TITLE
Fix/dataset name and version label (e.g. "vv2019.1")

### DIFF
--- a/src/components/DatasetCard/index.tsx
+++ b/src/components/DatasetCard/index.tsx
@@ -11,6 +11,7 @@ interface DatasetCardProps extends DatasetMetaData {
 
 const DatasetCard: React.FunctionComponent<DatasetCardProps> = ({
     title,
+    name,
     version,
     description,
     handleSelectDataset,
@@ -21,12 +22,12 @@ const DatasetCard: React.FunctionComponent<DatasetCardProps> = ({
 }: DatasetCardProps) => {
     // Prefix version number with a "v" if necessary
     const versionPrefixed = version.startsWith("v") ? version : `v${version}`;
-    
+
     const displayTitle = (
         <>
             <div>
                 {userData.isNew && <Tag color="purple">beta</Tag>}
-                {title}
+                {title ? title : name}
             </div>
             <span className={styles.version}>{versionPrefixed}</span>
             {userData.inReview && (


### PR DESCRIPTION
Problem
=======
Resolves: [backwards compatibility with old name and version numbers](https://aicsjira.corp.alleninstitute.org/browse/CFE-99)

Solution
========
1. Only append "v" to the version name if it is needed
2. Use dataset name instead of title if title isn't present

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

Screenshots (optional):
-----------------------

### Before (staging):

![image](https://user-images.githubusercontent.com/12690133/136103592-f0561e30-752f-4c9c-9b27-e2460657aadb.png)

### After:

![image](https://user-images.githubusercontent.com/12690133/136103510-09725581-bb44-416b-953f-e12d8307036f.png)
