### PR TITLE
fix issue with missing albums data never finishing

### DIFF
--- a/src/state/metadata/logics.ts
+++ b/src/state/metadata/logics.ts
@@ -167,7 +167,8 @@ const requestAlbumData = createLogic({
             .then(done)
             .catch((reason: string) => {
                 console.log(reason); // tslint:disable-line:no-console
-            });
+            })
+            .then(() => done());
     },
     processOptions: {
         successType: RECEIVE_ALBUM_DATA,


### PR DESCRIPTION
Problem
=======
Working with Matheus to get some test data into CFE's internal deployment, we found that CFE was hanging when album data was missing.

Solution
========
In the case of an error fetching albums data, we still need to call the "done" function.  This is treated the same way in the requestFeatureData and requestCellLineDefs logic right above this code.

## Type of change

* Bug fix (non-breaking change which fixes an issue)
