### PR TITLE
Feature/new colors cellsystems data

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -125,7 +125,7 @@ export const VIEWER_CHANNEL_SETTINGS: {
               channelNameMapping: "" | { test: RegExp; label: string }[];
               groupToChannelNameMap: "" | { [key: string]: string[] };
               channelsEnabled?: number[];
-              initialChannelSettings?: { [key: string]: { color: [number, number, number] } };
+              initialChannelSettings?: { [key: string]: { color: string } };
           }
         | undefined;
 } = {
@@ -139,11 +139,11 @@ export const VIEWER_CHANNEL_SETTINGS: {
         groupToChannelNameMap: {},
         channelsEnabled: [0, 1, 3, 4],
         initialChannelSettings: {
-            "0": { color: [255, 255, 255] },
-            "1": { color: [0, 255, 255] },
-            "2": { color: [128, 128, 128] },
-            "3": { color: [255, 0, 255] },
-            "4": { color: [0, 255, 0] },
+            "0": { color: "ffffff" },
+            "1": { color: "00ffff" },
+            "2": { color: "808080" },
+            "3": { color: "ff00ff" },
+            "4": { color: "00ff00" },
         },
     },
     cellsystems_live: {
@@ -151,10 +151,10 @@ export const VIEWER_CHANNEL_SETTINGS: {
         groupToChannelNameMap: {},
         channelsEnabled: [1, 2],
         initialChannelSettings: {
-            "0": { color: [255, 0, 255] },
-            "1": { color: [255, 255, 255] },
-            "2": { color: [0, 255, 255] },
-            "3": { color: [128, 128, 128] },
+            "0": { color: "ff00ff" },
+            "1": { color: "ffffff" },
+            "2": { color: "00ffff" },
+            "3": { color: "808080" },
         },
     },
 };

--- a/src/containers/Cfe/selectors.ts
+++ b/src/containers/Cfe/selectors.ts
@@ -27,7 +27,7 @@ export interface VolumeViewerProps {
     channelNameMapping?: { label: string; test: RegExp }[] | "";
     groupToChannelNameMap?: { [key: string]: string[] } | "";
     channelsEnabled?: number[];
-    initialChannelSettings?: { [key: string]: { color: [number, number, number] } };
+    initialChannelSettings?: { [key: string]: { color: string } };
 }
 
 export const getPropsForVolumeViewer = createSelector(


### PR DESCRIPTION
Problem
=======
needed new per-channel colors.  Also realized first attempt was passing color data in the wrong format.

Solution
========
Assigned new colors from @thao-do and verified they are working.

## Type of change

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Confirm that cellsystems-live and cellsystems-fish datasets use a consistent cyan/magenta/white/green color scheme when run with these code changes.

