### PR TITLE
fix thumbnail indexing

### DIFF
--- a/src/containers/MainPlotContainer/selectors.ts
+++ b/src/containers/MainPlotContainer/selectors.ts
@@ -96,10 +96,10 @@ export const getPlotlyCustomData = createSelector(
     (filteredCellData: DataForPlot): PlotlyCustomData[] => {
         const thumbnailPaths = filteredCellData.labels.thumbnailPaths;
         const indices = filteredCellData.indices;
-        return map(indices, (index) => {
+        return map(indices, (cellIndex, i) => {
             return {
-                index,
-                thumbnailPath: thumbnailPaths[index],
+                index: cellIndex,
+                thumbnailPath: thumbnailPaths[i],
             };
         });
     }


### PR DESCRIPTION
Problem
=======
From Graham: 
```
Mac Monterey 12.4 running latest Chrome. 
Opened cfe and selected main variance dataset.  
Delesected all and then tried to load only Endoplasmic reticulum.  
No thumnails show up and clicking any dots won't load anything into the gallery.
Same issue for Mitochondria... probably all of them
Thumbs etc only available when ShowAll
```

Solution
========
Thumbnail in plot was using wrong index.

## Type of change

* Bug fix (non-breaking change which fixes an issue)

