### PR TITLE
Feature/variance align control

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,9 +30,9 @@
             }
         },
         "@aics/web-3d-viewer": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/@aics/web-3d-viewer/-/web-3d-viewer-2.4.1.tgz",
-            "integrity": "sha512-ThnmmvcLeBJtarFz6ll6kHp8nEv9peHV6jlIkPWA2mAQLqHYHVJCtLFwZ7leoYRu8zvP3kBIlgXRnowDibkdFA==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@aics/web-3d-viewer/-/web-3d-viewer-2.5.0.tgz",
+            "integrity": "sha512-JRWyrmp8wypluJAG1KJL4CYnasusFdXcYobcH1RB5nIYD+Qacrba7zuCwbT3sqiLGOSmnoMrMoTGTAa0Ft0frg==",
             "requires": {
                 "@aics/volume-viewer": "^2.7.0",
                 "color-string": "^1.5.3",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     },
     "dependencies": {
         "@aics/browsing-context-messaging": "~1.1",
-        "@aics/web-3d-viewer": "^2.4.1",
+        "@aics/web-3d-viewer": "^2.5.0",
         "@ant-design/icons": "^4.2.2",
         "antd": "^3.26.20",
         "axios": "^0.21.1",

--- a/src/components/AlignControl/index.tsx
+++ b/src/components/AlignControl/index.tsx
@@ -1,6 +1,14 @@
-import { Radio } from "antd";
+import { InfoCircleOutlined } from "@ant-design/icons";
+import { Radio, Tooltip } from "antd";
 import React from "react";
 import { createPortal } from "react-dom";
+
+const infoText = `\
+For the associated publication, single cell images were aligned before feature extraction. The \
+apical basal axis of the cell (which is the z-axis in the lab frame of reference) was preserved \
+and we aligned the cells by rotation in the xy-plane. Cells and nuclei are rotated such that the \
+longest cell axis falls along the x-axis.\
+`;
 
 type AlignControlProps = {
     parent: HTMLElement;
@@ -10,16 +18,27 @@ type AlignControlProps = {
 
 const AlignControl: React.FC<AlignControlProps> = ({ aligned, setAligned, parent }) =>
     createPortal(
-        <span className="viewer-toolbar-left viewer-toolbar-group">
-            <span>Aligned:</span>
-            <Radio.Group value={aligned} onChange={({ target }) => setAligned(target.value)}>
-                <Radio.Button key={0} value={false}>
-                    Off
-                </Radio.Button>
-                <Radio.Button key={1} value={true}>
-                    On
-                </Radio.Button>
-            </Radio.Group>
+        <span className="viewer-toolbar-left">
+            <span className="viewer-toolbar-group">
+                <span>Alignment</span>
+                <Tooltip title={infoText} placement="bottom">
+                    <InfoCircleOutlined />
+                </Tooltip>
+            </span>
+            <span className="viewer-toolbar-group">
+                <Radio.Group value={aligned} onChange={({ target }) => setAligned(target.value)}>
+                    <Tooltip title="Turn on alignment" placement="bottom">
+                        <Radio.Button key={0} value={false}>
+                            Off
+                        </Radio.Button>
+                    </Tooltip>
+                    <Tooltip title="Turn off alignment" placement="bottom">
+                        <Radio.Button key={1} value={true}>
+                            On
+                        </Radio.Button>
+                    </Tooltip>
+                </Radio.Group>
+            </span>
         </span>,
         parent
     );

--- a/src/components/AlignControl/index.tsx
+++ b/src/components/AlignControl/index.tsx
@@ -18,7 +18,7 @@ type AlignControlProps = {
 
 const AlignControl: React.FC<AlignControlProps> = ({ aligned, setAligned, parent }) =>
     createPortal(
-        <span className="viewer-toolbar-left">
+        <>
             <span className="viewer-toolbar-group">
                 <span>Alignment</span>
                 <Tooltip title={infoText} placement="bottom">
@@ -39,7 +39,7 @@ const AlignControl: React.FC<AlignControlProps> = ({ aligned, setAligned, parent
                     </Tooltip>
                 </Radio.Group>
             </span>
-        </span>,
+        </>,
         parent
     );
 

--- a/src/components/AlignControl/index.tsx
+++ b/src/components/AlignControl/index.tsx
@@ -1,0 +1,27 @@
+import { Radio } from "antd";
+import React from "react";
+import { createPortal } from "react-dom";
+
+type AlignControlProps = {
+    parent: HTMLElement;
+    aligned: boolean;
+    setAligned: (aligned: boolean) => void;
+};
+
+const AlignControl: React.FC<AlignControlProps> = ({ aligned, setAligned, parent }) =>
+    createPortal(
+        <span className="viewer-toolbar-left viewer-toolbar-group">
+            <span>Aligned:</span>
+            <Radio.Group value={aligned} onChange={({ target }) => setAligned(target.value)}>
+                <Radio.Button key={0} value={false}>
+                    Off
+                </Radio.Button>
+                <Radio.Button key={1} value={true}>
+                    On
+                </Radio.Button>
+            </Radio.Group>
+        </span>,
+        parent
+    );
+
+export default AlignControl;

--- a/src/components/CellViewer/index.tsx
+++ b/src/components/CellViewer/index.tsx
@@ -28,6 +28,7 @@ const CellViewer: React.FunctionComponent<VolumeViewerProps> = (props) => {
                 cellDownloadHref={props.cellDownloadHref}
                 fovPath={props.fovPath}
                 viewerChannelSettings={props.viewerChannelSettings}
+                transform={props.transform}
                 onControlPanelToggle={props.onControlPanelToggle}
                 appHeight="100%"
                 canvasMargin="0 120px 0 0"

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -15,6 +15,7 @@ export const FOV_THUMBNAIL_PATH = "fovThumbnailPath";
 export const FOV_VOLUME_VIEWER_PATH = "fovVolumeviewerPath";
 export const THUMBNAIL_PATH = "thumbnailPath";
 export const VOLUME_VIEWER_PATH = "volumeviewerPath";
+export const TRANSFORM = "transform";
 
 export type FILE_INFO_KEY =
     | typeof CELL_ID_KEY

--- a/src/containers/Cfe/index.tsx
+++ b/src/containers/Cfe/index.tsx
@@ -24,9 +24,6 @@ const SMALL_SCREEN_WARNING_BREAKPOINT = 768;
 const PLOT_TAB_KEY = "plot";
 const VIEWER_TAB_KEY = "3d-viewer";
 
-// TODO make it a prop or something
-const SHOW_ALIGN_BUTTON = true;
-
 interface CfeProps {
     galleryCollapsed: boolean;
     toggleGallery: ActionCreator<BoolToggleAction>;
@@ -35,6 +32,7 @@ interface CfeProps {
     showSmallScreenWarning: boolean;
     setShowSmallScreenWarning: ActionCreator<SetSmallScreenWarningAction>;
     requestFeatureData: ActionCreator<RequestAction>;
+    showAlignControl: boolean;
     alignActive: boolean;
     setAlignActive: ActionCreator<SetAlignActiveAction>;
     viewerHeader: { cellId: string; label: string; value: string };
@@ -74,7 +72,7 @@ class Cfe extends React.Component<CfeProps, CfeState> {
 
     public componentDidUpdate = (prevProps: CfeProps, prevState: CfeState) => {
         const { currentTab } = this.state;
-        if (SHOW_ALIGN_BUTTON) {
+        if (this.props.showAlignControl) {
             document.querySelector(".viewer-toolbar")?.prepend(this.alignContainer);
         }
         if (prevState.currentTab !== currentTab && currentTab === VIEWER_TAB_KEY) {
@@ -216,7 +214,7 @@ class Cfe extends React.Component<CfeProps, CfeState> {
                             onControlPanelToggle={this.onControlPanelToggle}
                             {...this.props.volumeViewerProps}
                         />
-                        {SHOW_ALIGN_BUTTON && (
+                        {this.props.showAlignControl && (
                             <AlignControl
                                 parent={this.alignContainer}
                                 aligned={this.props.alignActive}
@@ -237,6 +235,7 @@ function mapStateToProps(state: State) {
         thumbnailRoot: selectionStateBranch.selectors.getThumbnailRoot(state),
         showSmallScreenWarning: metadataStateBranch.selectors.getShowSmallScreenWarning(state),
         viewerHeader: getViewerHeader(state),
+        showAlignControl: selectionStateBranch.selectors.getSelected3DCelHasTransform(state),
         alignActive: selectionStateBranch.selectors.getAlignActive(state),
     };
 }

--- a/src/containers/Cfe/index.tsx
+++ b/src/containers/Cfe/index.tsx
@@ -8,7 +8,7 @@ import classNames from "classnames";
 import CellViewer from "../../components/CellViewer/index";
 import SmallScreenWarning from "../../components/SmallScreenWarning";
 import selectionStateBranch from "../../state/selection";
-import { BoolToggleAction } from "../../state/selection/types";
+import { BoolToggleAction, SetAlignActiveAction } from "../../state/selection/types";
 import metadataStateBranch from "../../state/metadata";
 import { State } from "../../state/types";
 import ThumbnailGallery from "../ThumbnailGallery";
@@ -35,6 +35,8 @@ interface CfeProps {
     showSmallScreenWarning: boolean;
     setShowSmallScreenWarning: ActionCreator<SetSmallScreenWarningAction>;
     requestFeatureData: ActionCreator<RequestAction>;
+    alignActive: boolean;
+    setAlignActive: ActionCreator<SetAlignActiveAction>;
     viewerHeader: { cellId: string; label: string; value: string };
 }
 
@@ -220,8 +222,8 @@ class Cfe extends React.Component<CfeProps, CfeState> {
                         {SHOW_ALIGN_BUTTON && (
                             <AlignControl
                                 parent={this.alignContainer}
-                                aligned={false}
-                                setAligned={console.log}
+                                aligned={this.props.alignActive}
+                                setAligned={this.props.setAlignActive}
                             />
                         )}
                     </Content>
@@ -238,6 +240,7 @@ function mapStateToProps(state: State) {
         thumbnailRoot: selectionStateBranch.selectors.getThumbnailRoot(state),
         showSmallScreenWarning: metadataStateBranch.selectors.getShowSmallScreenWarning(state),
         viewerHeader: getViewerHeader(state),
+        alignActive: selectionStateBranch.selectors.getAlignActive(state),
     };
 }
 
@@ -245,6 +248,7 @@ const dispatchToPropsMap = {
     toggleGallery: selectionStateBranch.actions.toggleGallery,
     setShowSmallScreenWarning: metadataStateBranch.actions.setShowSmallScreenWarning,
     requestFeatureData: metadataStateBranch.actions.requestFeatureData,
+    setAlignActive: selectionStateBranch.actions.setAlignActive,
 };
 
 export default connect(mapStateToProps, dispatchToPropsMap)(Cfe);

--- a/src/containers/Cfe/index.tsx
+++ b/src/containers/Cfe/index.tsx
@@ -73,7 +73,7 @@ class Cfe extends React.Component<CfeProps, CfeState> {
     public componentDidUpdate = (prevProps: CfeProps, prevState: CfeState) => {
         const { currentTab } = this.state;
         if (this.props.showAlignControl) {
-            document.querySelector(".viewer-toolbar")?.prepend(this.alignContainer);
+            document.querySelector(".viewer-toolbar-left")?.prepend(this.alignContainer);
         }
         if (prevState.currentTab !== currentTab && currentTab === VIEWER_TAB_KEY) {
             // Need to manually trigger events that depend on the window resizing,

--- a/src/containers/Cfe/index.tsx
+++ b/src/containers/Cfe/index.tsx
@@ -13,6 +13,7 @@ import metadataStateBranch from "../../state/metadata";
 import { State } from "../../state/types";
 import ThumbnailGallery from "../ThumbnailGallery";
 import PlotTab from "../../components/PlotTab";
+import AlignControl from "../../components/AlignControl";
 import { SetSmallScreenWarningAction, RequestAction } from "../../state/metadata/types";
 import { getPropsForVolumeViewer, getViewerHeader, VolumeViewerProps } from "./selectors";
 
@@ -22,6 +23,9 @@ import styles from "./style.css";
 const SMALL_SCREEN_WARNING_BREAKPOINT = 768;
 const PLOT_TAB_KEY = "plot";
 const VIEWER_TAB_KEY = "3d-viewer";
+
+// TODO make it a prop or something
+const SHOW_ALIGN_BUTTON = true;
 
 interface CfeProps {
     galleryCollapsed: boolean;
@@ -46,6 +50,12 @@ interface CfeState {
 class Cfe extends React.Component<CfeProps, CfeState> {
     private static panelKeys = ["groupings", "selections"];
 
+    // Weird hack to get align button into the viewer toolbar:
+    // 1. create this element as a container to hold the align control
+    // 2. render the align control into the container with a ReactDOM portal
+    // 3. inject the container into the toolbar with regular old DOM methods in componentDidUpdate
+    private alignContainer = document.createElement("span");
+
     public state: CfeState = {
         defaultActiveKey: [Cfe.panelKeys[0]],
         dontShowSmallScreenWarningAgain: false,
@@ -62,6 +72,12 @@ class Cfe extends React.Component<CfeProps, CfeState> {
 
     public componentDidUpdate = (prevProps: CfeProps, prevState: CfeState) => {
         const { currentTab } = this.state;
+        if (SHOW_ALIGN_BUTTON) {
+            const toolbar = document.querySelector(".viewer-toolbar");
+            if (toolbar) {
+                toolbar.prepend(this.alignContainer);
+            }
+        }
         if (prevState.currentTab !== currentTab && currentTab === VIEWER_TAB_KEY) {
             // Need to manually trigger events that depend on the window resizing,
             // otherwise the 3D viewer canvas will have 0 height and 0 width.
@@ -201,6 +217,13 @@ class Cfe extends React.Component<CfeProps, CfeState> {
                             onControlPanelToggle={this.onControlPanelToggle}
                             {...this.props.volumeViewerProps}
                         />
+                        {SHOW_ALIGN_BUTTON && (
+                            <AlignControl
+                                parent={this.alignContainer}
+                                aligned={false}
+                                setAligned={console.log}
+                            />
+                        )}
                     </Content>
                 </Layout>
             </Layout>

--- a/src/containers/Cfe/index.tsx
+++ b/src/containers/Cfe/index.tsx
@@ -8,7 +8,7 @@ import classNames from "classnames";
 import CellViewer from "../../components/CellViewer/index";
 import SmallScreenWarning from "../../components/SmallScreenWarning";
 import selectionStateBranch from "../../state/selection";
-import { BoolToggleAction, SetAlignActiveAction } from "../../state/selection/types";
+import { BoolToggleAction } from "../../state/selection/types";
 import metadataStateBranch from "../../state/metadata";
 import { State } from "../../state/types";
 import ThumbnailGallery from "../ThumbnailGallery";
@@ -34,7 +34,7 @@ interface CfeProps {
     requestFeatureData: ActionCreator<RequestAction>;
     showAlignControl: boolean;
     alignActive: boolean;
-    setAlignActive: ActionCreator<SetAlignActiveAction>;
+    setAlignActive: ActionCreator<BoolToggleAction>;
     viewerHeader: { cellId: string; label: string; value: string };
 }
 

--- a/src/containers/Cfe/index.tsx
+++ b/src/containers/Cfe/index.tsx
@@ -75,10 +75,7 @@ class Cfe extends React.Component<CfeProps, CfeState> {
     public componentDidUpdate = (prevProps: CfeProps, prevState: CfeState) => {
         const { currentTab } = this.state;
         if (SHOW_ALIGN_BUTTON) {
-            const toolbar = document.querySelector(".viewer-toolbar");
-            if (toolbar) {
-                toolbar.prepend(this.alignContainer);
-            }
+            document.querySelector(".viewer-toolbar")?.prepend(this.alignContainer);
         }
         if (prevState.currentTab !== currentTab && currentTab === VIEWER_TAB_KEY) {
             // Need to manually trigger events that depend on the window resizing,

--- a/src/containers/Cfe/index.tsx
+++ b/src/containers/Cfe/index.tsx
@@ -235,7 +235,7 @@ function mapStateToProps(state: State) {
         thumbnailRoot: selectionStateBranch.selectors.getThumbnailRoot(state),
         showSmallScreenWarning: metadataStateBranch.selectors.getShowSmallScreenWarning(state),
         viewerHeader: getViewerHeader(state),
-        showAlignControl: selectionStateBranch.selectors.getSelected3DCelHasTransform(state),
+        showAlignControl: selectionStateBranch.selectors.getSelected3DCellHasTransform(state),
         alignActive: selectionStateBranch.selectors.getAlignActive(state),
     };
 }

--- a/src/containers/Cfe/selectors.ts
+++ b/src/containers/Cfe/selectors.ts
@@ -41,13 +41,7 @@ export const getPropsForVolumeViewer = createSelector(
         getViewerChannelSettings,
         getAlignActive,
     ],
-    (
-        fileInfo: FileInfo,
-        dataRoot,
-        downloadRoot,
-        viewerChannelSettings,
-        alignActive
-    ): VolumeViewerProps => {
+    (fileInfo, dataRoot, downloadRoot, viewerChannelSettings, alignActive): VolumeViewerProps => {
         if (isEmpty(fileInfo)) {
             return {} as VolumeViewerProps;
         }
@@ -94,12 +88,7 @@ export const getPropsForVolumeViewer = createSelector(
             fovPath: parentCellPath,
             cellDownloadHref: mainDownloadHref,
             fovDownloadHref: parentDownloadHref,
-            transform: alignActive
-                ? {
-                      translate: [0, 0, 0] as [number, number, number],
-                      rotate: [0, Math.PI * 0.75, 0] as [number, number, number],
-                  }
-                : undefined,
+            transform: alignActive ? fileInfo.transform : undefined,
             viewerChannelSettings,
         };
         return props;

--- a/src/containers/Cfe/selectors.ts
+++ b/src/containers/Cfe/selectors.ts
@@ -2,6 +2,7 @@ import { isEmpty } from "lodash";
 import { createSelector } from "reselect";
 import { FileInfo, MeasuredFeatureDef } from "../../state/metadata/types";
 import {
+    getAlignActive,
     getDownloadRoot,
     getGroupByFeatureDef,
     getSelected3DCellFileInfo,
@@ -25,12 +26,28 @@ export interface VolumeViewerProps {
     fovDownloadHref: string;
     cellDownloadHref: string;
     viewerChannelSettings?: ViewerChannelSettings;
+    transform?: {
+        translate: [number, number, number];
+        rotate: [number, number, number];
+    };
     onControlPanelToggle?(collapsed: boolean): void;
 }
 
 export const getPropsForVolumeViewer = createSelector(
-    [getSelected3DCellFileInfo, getVolumeViewerDataRoot, getDownloadRoot, getViewerChannelSettings],
-    (fileInfo: FileInfo, dataRoot, downloadRoot, viewerChannelSettings): VolumeViewerProps => {
+    [
+        getSelected3DCellFileInfo,
+        getVolumeViewerDataRoot,
+        getDownloadRoot,
+        getViewerChannelSettings,
+        getAlignActive,
+    ],
+    (
+        fileInfo: FileInfo,
+        dataRoot,
+        downloadRoot,
+        viewerChannelSettings,
+        alignActive
+    ): VolumeViewerProps => {
         if (isEmpty(fileInfo)) {
             return {} as VolumeViewerProps;
         }
@@ -77,6 +94,12 @@ export const getPropsForVolumeViewer = createSelector(
             fovPath: parentCellPath,
             cellDownloadHref: mainDownloadHref,
             fovDownloadHref: parentDownloadHref,
+            transform: alignActive
+                ? {
+                      translate: [0, 0, 0] as [number, number, number],
+                      rotate: [0, Math.PI * 0.75, 0] as [number, number, number],
+                  }
+                : undefined,
             viewerChannelSettings,
         };
         return props;
@@ -97,10 +120,6 @@ export const getViewerHeader = createSelector(
         const cellId = fileInfo.volumeviewerPath ? fileInfo.CellId : fileInfo.FOVId;
         label = groupByFeatureDef.displayName;
         value = fileInfo[GROUP_BY_KEY] || "";
-        return {
-            cellId,
-            label,
-            value,
-        };
+        return { cellId, label, value };
     }
 );

--- a/src/containers/Cfe/style.css
+++ b/src/containers/Cfe/style.css
@@ -79,7 +79,7 @@
     transition: left 0.2s;
 }
 
-@media screen and (max-width: 950px) {
+@media screen and (max-width: 1000px) {
     .viewer-title-container {
         justify-content: right;
         padding-right: 12px;

--- a/src/containers/Cfe/test/selectors.test.ts
+++ b/src/containers/Cfe/test/selectors.test.ts
@@ -55,6 +55,7 @@ describe("Viewer selectors", () => {
                 fovDownloadHref: "&id=F12762",
                 fovPath: "fovVolumeviewerPath",
                 viewerChannelSettings: {},
+                transform: undefined,
             });
         });
         it("if there is no single cell data, returns fov info as main info", () => {
@@ -75,6 +76,7 @@ describe("Viewer selectors", () => {
                 fovDownloadHref: "",
                 fovPath: "",
                 viewerChannelSettings: {},
+                transform: undefined,
             });
         });
         it("if dataset has channelNameMapping data, it will be included", () => {

--- a/src/state/metadata/types.ts
+++ b/src/state/metadata/types.ts
@@ -5,6 +5,7 @@ import {
     FOV_VOLUME_VIEWER_PATH,
     GROUP_BY_KEY,
     THUMBNAIL_PATH,
+    TRANSFORM,
     VOLUME_VIEWER_PATH,
 } from "../../constants";
 import { Megaset } from "../image-dataset/types";
@@ -36,6 +37,10 @@ export interface FileInfo {
     [FOV_VOLUME_VIEWER_PATH]: string;
     [THUMBNAIL_PATH]: string;
     [VOLUME_VIEWER_PATH]: string;
+    [TRANSFORM]?: {
+        translate: [number, number, number];
+        rotate: [number, number, number];
+    };
     [GROUP_BY_KEY]?: string;
     index?: number; // added to the data after it's loaded for fast lookup into other array
 }
@@ -94,7 +99,7 @@ export interface DataForPlot {
 // ACTIONS
 
 export interface ReceiveAction {
-    payload: {[key: string]: any};
+    payload: { [key: string]: any };
     type: string;
 }
 

--- a/src/state/selection/actions.ts
+++ b/src/state/selection/actions.ts
@@ -24,6 +24,7 @@ import {
     SELECT_ARRAY_OF_POINTS,
     CLEAR_DATASET,
     CHANGE_GROUP_BY_CATEGORY,
+    SET_ALIGN_ACTIVE,
 } from "./constants";
 import {
     BoolToggleAction,
@@ -203,3 +204,9 @@ export function requestCellFileInfoByArrayOfCellIds(payload: string[]) {
     };
 }
 
+export function setAlignActive(payload: boolean) {
+    return {
+        payload,
+        type: SET_ALIGN_ACTIVE,
+    };
+}

--- a/src/state/selection/constants.ts
+++ b/src/state/selection/constants.ts
@@ -1,6 +1,4 @@
-import {
-    MY_SELECTIONS_ID,
-} from "../../constants/index";
+import { MY_SELECTIONS_ID } from "../../constants/index";
 import { makeConstant } from "../util";
 
 const makeSelectionConstant = (constant: string) => makeConstant("selection", constant);
@@ -11,7 +9,9 @@ export const SELECT_GROUP_VIA_PLOT = makeSelectionConstant("select_group");
 export const DESELECT_POINT = makeSelectionConstant("deselect-point");
 export const SELECT_POINT = makeSelectionConstant("select-point");
 export const DESELECT_ALL_POINTS = makeSelectionConstant("deselect-all-points");
-export const TOGGLE_FILTER_BY_CATEGORY_NAME = makeSelectionConstant("toggle-filter-by-category-name");
+export const TOGGLE_FILTER_BY_CATEGORY_NAME = makeSelectionConstant(
+    "toggle-filter-by-category-name"
+);
 export const OPEN_CELL_IN_3D = makeSelectionConstant("open-cell-in-3d");
 export const TOGGLE_APPLY_SELECTION_SET_COLOR = makeSelectionConstant("apply-selection-set-color");
 export const DESELECT_GROUP_OF_POINTS = makeSelectionConstant("deselect-group");
@@ -22,12 +22,11 @@ export const CHANGE_HOVERED_POINT_ID = makeSelectionConstant("change-hovered-poi
 export const CHANGE_HOVERED_GALLERY_CARD = makeSelectionConstant("change-hovered-gallery-card");
 export const CHANGE_SELECTED_ALBUM = makeSelectionConstant("change-selected-album");
 export const TOGGLE_GALLERY_OPEN_CLOSE = makeSelectionConstant("toggle-gallery");
+export const SET_ALIGN_ACTIVE = makeSelectionConstant("set-align-active");
 export const REQUEST_CELL_FILE_INFO_BY_CELL_ID = makeSelectionConstant(
     "REQUEST_CELL_FILE_INFO_BY_CELL_ID"
 );
-export const RECEIVE_FILE_INFO = makeSelectionConstant(
-    "RECEIVE_CELL_FILE_INFO"
-);
+export const RECEIVE_FILE_INFO = makeSelectionConstant("RECEIVE_CELL_FILE_INFO");
 export const RECEIVE_FILE_INFO_FOR_SELECTED_CELL = makeSelectionConstant(
     "RECEIVE_SELECTED_FILE_INFO"
 );
@@ -84,7 +83,7 @@ export const INITIAL_COLORS = [
     "#fddb02",
     "#f7db78",
     "#f9a558",
-    ];
+];
 
 export const INITIAL_SELECTION_COLORS = [
     "#8dd3c7",

--- a/src/state/selection/reducer.ts
+++ b/src/state/selection/reducer.ts
@@ -1,8 +1,4 @@
-import {
-    filter,
-    pickBy,
-    uniqBy,
-} from "lodash";
+import { filter, pickBy, uniqBy } from "lodash";
 import { AnyAction } from "redux";
 import { SelectedGroups } from "..";
 
@@ -35,6 +31,7 @@ import {
     RECEIVE_FILE_INFO_FOR_SELECTED_ARRAY_OF_CELLS,
     CLEAR_DATASET,
     CHANGE_GROUP_BY_CATEGORY,
+    SET_ALIGN_ACTIVE,
 } from "./constants";
 import {
     BoolToggleAction,
@@ -55,6 +52,7 @@ import {
     SelectAxisAction,
     SelectionStateBranch,
     SelectPointAction,
+    SetAlignActiveAction,
 } from "./types";
 
 export const initialState = {
@@ -87,6 +85,7 @@ export const initialState = {
     thumbnailRoot: "",
     downloadRoot: "",
     volumeViewerDataRoot: "",
+    alignActive: false,
 };
 
 const actionToConfigMap: TypeToDescriptionMap = {
@@ -266,6 +265,14 @@ const actionToConfigMap: TypeToDescriptionMap = {
         perform: (state: SelectionStateBranch, action: ReceiveCellFileInfoAction) => ({
             ...state,
             selectedAlbumFileInfo: action.payload,
+        }),
+    },
+    [SET_ALIGN_ACTIVE]: {
+        accepts: (action: AnyAction): action is SetAlignActiveAction =>
+            action.type === SET_ALIGN_ACTIVE,
+        perform: (state: SelectionStateBranch, action: SetAlignActiveAction) => ({
+            ...state,
+            alignActive: action.payload,
         }),
     },
 };

--- a/src/state/selection/reducer.ts
+++ b/src/state/selection/reducer.ts
@@ -52,7 +52,6 @@ import {
     SelectAxisAction,
     SelectionStateBranch,
     SelectPointAction,
-    SetAlignActiveAction,
 } from "./types";
 
 export const initialState = {
@@ -268,9 +267,9 @@ const actionToConfigMap: TypeToDescriptionMap = {
         }),
     },
     [SET_ALIGN_ACTIVE]: {
-        accepts: (action: AnyAction): action is SetAlignActiveAction =>
+        accepts: (action: AnyAction): action is BoolToggleAction =>
             action.type === SET_ALIGN_ACTIVE,
-        perform: (state: SelectionStateBranch, action: SetAlignActiveAction) => ({
+        perform: (state: SelectionStateBranch, action: BoolToggleAction) => ({
             ...state,
             alignActive: action.payload,
         }),

--- a/src/state/selection/selectors.ts
+++ b/src/state/selection/selectors.ts
@@ -447,7 +447,7 @@ export const getSelected3DCellFOV = createSelector(
     }
 );
 
-export const getSelected3DCelHasTransform = createSelector(
+export const getSelected3DCellHasTransform = createSelector(
     [getSelected3DCellFileInfo],
     (fileInfo): boolean => !!fileInfo.transform
 );

--- a/src/state/selection/selectors.ts
+++ b/src/state/selection/selectors.ts
@@ -12,12 +12,7 @@ import {
 } from "lodash";
 import { createSelector } from "reselect";
 
-import {
-    ARRAY_OF_CELL_IDS_KEY,
-    CELL_ID_KEY,
-    FOV_ID_KEY,
-    GROUP_BY_KEY,
-} from "../../constants";
+import { ARRAY_OF_CELL_IDS_KEY, CELL_ID_KEY, FOV_ID_KEY, GROUP_BY_KEY } from "../../constants";
 import {
     getPerCellDataForPlot,
     getMeasuredFeaturesKeys,
@@ -75,6 +70,7 @@ export const getSelectedAlbumFileInfo = (state: State): FileInfo[] =>
 export const getDownloadRoot = (state: State): string => state.selection.downloadRoot;
 export const getVolumeViewerDataRoot = (state: State): string =>
     state.selection.volumeViewerDataRoot;
+export const getAlignActive = (state: State): boolean => state.selection.alignActive;
 
 export const getSelectedDatasetName = createSelector(
     [getSelectedDataset],
@@ -179,7 +175,7 @@ export const getCategoryGroupColorsAndNames = createSelector(
     }
 );
 
-// =============================================================================================== 
+// ===============================================================================================
 
 // MAIN PLOT SELECTORS
 // ===================
@@ -203,9 +199,12 @@ export const getGroupingCategoryNamesAsArray = createSelector(
      * ["beta-actin", "beta-actin", "tom20", "tom20"]
      */
     [getPerCellDataForPlot, getGroupByFeatureDef],
-    (perCellDataForPlot: DataForPlot, groupByCategoryFeatureDef: DiscreteMeasuredFeatureDef): string[] => {
+    (
+        perCellDataForPlot: DataForPlot,
+        groupByCategoryFeatureDef: DiscreteMeasuredFeatureDef
+    ): string[] => {
         const categoryKey: string = groupByCategoryFeatureDef.key;
-        return map(perCellDataForPlot.values[categoryKey], (ele: (number | null)): string => {
+        return map(perCellDataForPlot.values[categoryKey], (ele: number | null): string => {
             const numeralRepresentationOfTheCategory = ele !== null ? ele.toString() : "";
             return getCategoryString(groupByCategoryFeatureDef, numeralRepresentationOfTheCategory);
         });

--- a/src/state/selection/selectors.ts
+++ b/src/state/selection/selectors.ts
@@ -447,6 +447,11 @@ export const getSelected3DCellFOV = createSelector(
     }
 );
 
+export const getSelected3DCelHasTransform = createSelector(
+    [getSelected3DCellFileInfo],
+    (fileInfo): boolean => !!fileInfo.transform
+);
+
 // ===============================================================================================
 
 // LASSOED or BOX SELECTED GROUPS SELECTORS

--- a/src/state/selection/types.ts
+++ b/src/state/selection/types.ts
@@ -1,7 +1,5 @@
 import { SelectedGroups } from "..";
-import {
-    CELL_ID_KEY,
-} from "../../constants";
+import { CELL_ID_KEY } from "../../constants";
 import { FileInfo } from "../metadata/types";
 
 export interface SelectionStateBranch {
@@ -28,6 +26,7 @@ export interface SelectionStateBranch {
     thumbnailRoot: string;
     downloadRoot: string;
     volumeViewerDataRoot: string;
+    alignActive: boolean;
 }
 
 export interface CellDataArrays {
@@ -70,7 +69,7 @@ export interface DeselectGroupOfPointsAction {
     type: string;
 }
 
-export interface  SelectPointAction {
+export interface SelectPointAction {
     payload: {
         id: string;
         index?: number;
@@ -106,7 +105,7 @@ export interface SelectedPointData {
     index: number;
     thumbnailPath: string;
     groupBy?: string;
-}   
+}
 
 export interface ChangeHoveredPointAction {
     payload: SelectedPointData;
@@ -162,7 +161,7 @@ export interface SelectArrayOfPointsAction {
 export interface SetHoveredCardAction {
     payload: SelectedPointData;
     type: string;
-};
+}
 
 export interface ClearDatasetAction {
     type: string;
@@ -170,5 +169,10 @@ export interface ClearDatasetAction {
 
 export interface ChangeGroupByCategory {
     payload: string;
+    type: string;
+}
+
+export interface SetAlignActiveAction {
+    payload: boolean;
     type: string;
 }

--- a/src/state/selection/types.ts
+++ b/src/state/selection/types.ts
@@ -171,8 +171,3 @@ export interface ChangeGroupByCategory {
     payload: string;
     type: string;
 }
-
-export interface SetAlignActiveAction {
-    payload: boolean;
-    type: string;
-}


### PR DESCRIPTION
Problem
=======
#113: "Variance data set single cell images have all been aligned, meaning they all have a translation in xy and a rotation about z.
We want to allow users of CFE to be able to see the 3d cells both aligned and unaligned."

Solution
========
Resolve #113: We've previously decided on a format to add transform data. Add new alignment control component, (somewhat hacky) code to inject it into the viewer toolbar, and associated redux plumbing to read transforms and manage aligned/unaligned state.

## Type of change
* New feature (non-breaking change which adds functionality)
* This change requires updated or new tests

Steps to Verify:
----------------
1. Run `npm install` to ensure the viewer is updated.
2. Load a dataset without any transform metadata (i.e. with `null` or nothing at all in the new `transform` field of `FileInfo`). Alignment control should not appear at all.
3. Load a dataset with transform metadata. Align controls should appear, with an info tooltip and On/Off radio buttons.
4. Click "On." The specified transform should be applied.

Screenshots (optional):
-----------------------
![image](https://user-images.githubusercontent.com/53030214/209029382-65dc0c28-b7ee-4dec-8745-2a22f9032a68.png)
![image](https://user-images.githubusercontent.com/53030214/209029280-a84d0dfe-e1df-472f-8ec8-597e518a981f.png)
(The screenshots above are running on a fake transform injected via redux devtools - this is not necessarily the actual alignment of this cell!)