### PR TITLE
allow dataset image to be empty

### DIFF
--- a/src/components/DatasetCard/index.tsx
+++ b/src/components/DatasetCard/index.tsx
@@ -45,11 +45,13 @@ const DatasetCard: React.FunctionComponent<DatasetCardProps> = ({
             hoverable
             bordered={false}
             cover={
-                <img
-                    className={styles.staticThumbnail}
-                    alt={`Snapshot of simulation for ${title}`}
-                    src={image}
-                />
+                image != "" ? (
+                    <img
+                        className={styles.staticThumbnail}
+                        alt={`Snapshot of simulation for ${title}`}
+                        src={image}
+                    />
+                ) : null
             }
             onClick={() => handleSelectDataset(id)}
         >


### PR DESCRIPTION
Problem
=======
Variance datasets were decided to have no thumbnail preview image on the main cards on the landing page.

Solution
========
Simply omit image if it's an empty string.

![Cell Feature Explorer 2023-01-03 13-14-14](https://user-images.githubusercontent.com/2193409/210443045-5a9ee408-7853-4d23-9362-1685732053f1.png)

## Type of change
* New feature (non-breaking change which adds functionality)
