### PR TITLE
use index to sort sub datasets

### DIFF
--- a/src/components/MegasetCard/index.tsx
+++ b/src/components/MegasetCard/index.tsx
@@ -27,7 +27,7 @@ const MegasetCard: React.FunctionComponent<MegasetCardProps> = ({
     // container instead of the container expanding to fit publications
     const maxWidth = numDatasets > 1 ? "100%" : datasetCardWidth;
 
-    const datasets = map(megaset.datasets).sort((a, b) => b.title.localeCompare(a.title))
+    const datasets = map(megaset.datasets).sort((a, b) => a.index - b.index)
     return (
         <div 
             key={megaset.name}

--- a/src/state/image-dataset/types.ts
+++ b/src/state/image-dataset/types.ts
@@ -22,6 +22,7 @@ export interface DatasetMetaData {
     id: string;
     description: string;
     image: string;
+    index: number;
     link?: string;
     manifest?: string;
     production?: boolean;


### PR DESCRIPTION
Problem
=======
We want the datasets to show up in the same order every time. We were using the title, but that's a bit arbitrary. 

Solution
========
Added an index in the data processing set, and I'm using that index here. This allows the dataset creator to define the order of the datasets. 

## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)

Change summary:
---------------
* Tidy, well formulated commit message
* Another great commit message
* Something else I/we did

Steps to Verify:
----------------
1. npm start
2. the datasets stay in the same order in their cards every time



