### PR TITLE
disable all download buttons if downloadRoot is empty

### DIFF
--- a/src/components/DownloadDropDownMenu/index.tsx
+++ b/src/components/DownloadDropDownMenu/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Dropdown, Icon, Menu } from "antd";
+import { Button, Dropdown, Icon, Menu, Tooltip } from "antd";
 import { CheckboxChangeEvent } from "antd/es/checkbox";
 import { ClickParam } from "antd/es/menu";
 import { includes, uniq } from "lodash";
@@ -7,6 +7,7 @@ import React, { MouseEvent } from "react";
 import { DownloadConfig } from "../../state/selection/types";
 
 import styles from "./style.css";
+import { NO_DOWNLOADS_TOOLTIP } from "../../constants";
 
 interface DownloadDropDownMenuProps {
     color: string;
@@ -17,6 +18,7 @@ interface DownloadDropDownMenuProps {
     closeable?: boolean;
     downloadConfig: DownloadConfig;
     downloadUrls: string[];
+    downloadRoot: string;
     hideable?: boolean;
     onBarClicked?: (clickEvent: CheckboxChangeEvent) => void;
     handleClose?: (id: number | string) => void;
@@ -109,7 +111,7 @@ export default class DownloadDropDownMenu extends React.Component<
     }
 
     public render() {
-        const { id, downloadUrls, downloadConfig } = this.props;
+        const { id, downloadUrls, downloadConfig, downloadRoot } = this.props;
         const alreadyDownloaded = this.state.alreadyDownloaded[downloadConfig.key];
         const menu = (
             <Menu className={styles.menu} onClick={this.handleMenuClick}>
@@ -125,23 +127,25 @@ export default class DownloadDropDownMenu extends React.Component<
                 ))}
             </Menu>
         );
-        return (downloadUrls.length > 0 &&
+        return (
             <div className={styles.container}>
-                <Dropdown
-                    overlay={menu}
-                    trigger={["click"]}
-                    onVisibleChange={this.handleDownloadMenuVisibleChange}
-                    visible={this.state.downloadMenuVisible}
-                >
-                    <Button
-                        size="small"
-                        className="ant-dropdown-link"
-                        id={id}
-                        onClick={this.onDownload}
+                <Tooltip title={downloadRoot === "" ? NO_DOWNLOADS_TOOLTIP : null}>
+                    <Dropdown
+                        overlay={menu}
+                        trigger={["click"]}
+                        onVisibleChange={this.handleDownloadMenuVisibleChange}
+                        visible={this.state.downloadMenuVisible}
                     >
-                        <Icon type="download" />
-                    </Button>
-                </Dropdown>
+                        <Button
+                            size="small"
+                            className="ant-dropdown-link"
+                            id={id}
+                            onClick={this.onDownload}
+                        >
+                            <Icon type="download" />
+                        </Button>
+                    </Dropdown>
+                </Tooltip>
             </div>
         );
     }

--- a/src/components/DownloadDropDownMenu/index.tsx
+++ b/src/components/DownloadDropDownMenu/index.tsx
@@ -127,7 +127,10 @@ export default class DownloadDropDownMenu extends React.Component<
                 ))}
             </Menu>
         );
-        const noDownloads = downloadRoot === ""; // could be downloadUrls.length === 0;
+        // we can not check for downloadUrls.length because there are some conditions where
+        // downloadUrls is empty but we still want to show the download button due to 
+        // initialization order in the app / React lifecycle concerns.
+        const noDownloads = downloadRoot === "";
         return (
             <div className={styles.container}>
                 <Tooltip title={noDownloads ? NO_DOWNLOADS_TOOLTIP : null}>

--- a/src/components/DownloadDropDownMenu/index.tsx
+++ b/src/components/DownloadDropDownMenu/index.tsx
@@ -140,8 +140,8 @@ export default class DownloadDropDownMenu extends React.Component<
                             size="small"
                             className={downloadUrls.length === 0 ? styles.disabledDownload : "ant-dropdown-link"}
                             id={id}
-                            onClick={this.onDownload}
-                            disabled={downloadUrls.length === 0}                        
+                            onClick={downloadUrls.length === 0 ? undefined : this.onDownload}
+                            disabled={downloadUrls.length === 0}
                         >
                             <Icon type="download" />
                         </Button>

--- a/src/components/DownloadDropDownMenu/index.tsx
+++ b/src/components/DownloadDropDownMenu/index.tsx
@@ -127,9 +127,10 @@ export default class DownloadDropDownMenu extends React.Component<
                 ))}
             </Menu>
         );
+        const noDownloads = downloadRoot === ""; // could be downloadUrls.length === 0;
         return (
             <div className={styles.container}>
-                <Tooltip title={downloadRoot === "" ? NO_DOWNLOADS_TOOLTIP : null}>
+                <Tooltip title={noDownloads ? NO_DOWNLOADS_TOOLTIP : null}>
                     <Dropdown
                         overlay={menu}
                         trigger={["click"]}
@@ -138,10 +139,10 @@ export default class DownloadDropDownMenu extends React.Component<
                     >
                         <Button
                             size="small"
-                            className={downloadUrls.length === 0 ? styles.disabledDownload : "ant-dropdown-link"}
+                            className={noDownloads ? styles.disabledDownload : "ant-dropdown-link"}
                             id={id}
-                            onClick={downloadUrls.length === 0 ? undefined : this.onDownload}
-                            disabled={downloadUrls.length === 0}
+                            onClick={noDownloads ? undefined : this.onDownload}
+                            disabled={noDownloads}
                         >
                             <Icon type="download" />
                         </Button>

--- a/src/components/DownloadDropDownMenu/index.tsx
+++ b/src/components/DownloadDropDownMenu/index.tsx
@@ -138,9 +138,10 @@ export default class DownloadDropDownMenu extends React.Component<
                     >
                         <Button
                             size="small"
-                            className="ant-dropdown-link"
+                            className={downloadUrls.length === 0 ? styles.disabledDownload : "ant-dropdown-link"}
                             id={id}
                             onClick={this.onDownload}
+                            disabled={downloadUrls.length === 0}                        
                         >
                             <Icon type="download" />
                         </Button>

--- a/src/components/DownloadDropDownMenu/index.tsx
+++ b/src/components/DownloadDropDownMenu/index.tsx
@@ -125,7 +125,7 @@ export default class DownloadDropDownMenu extends React.Component<
                 ))}
             </Menu>
         );
-        return (
+        return (downloadUrls.length > 0 &&
             <div className={styles.container}>
                 <Dropdown
                     overlay={menu}

--- a/src/components/DownloadDropDownMenu/style.css
+++ b/src/components/DownloadDropDownMenu/style.css
@@ -1,6 +1,10 @@
 .container {
     display: inline;
 }
+.container .disabled-download {
+    color: var(--dimgray);
+    opacity: 0.5;
+}
 
 .menu a{
     display: inline;

--- a/src/components/GalleryCard/index.tsx
+++ b/src/components/GalleryCard/index.tsx
@@ -55,6 +55,7 @@ const GalleryCard: React.SFC<GalleryCardProps> = (props) => {
         >
             3D
         </Button>,
+        (props.downloadHref !== "" || props.downloadFullField !== "") &&
         <Dropdown key={`${props.cellID}-download`} overlay={menu} trigger={["click"]}>
             <Button icon="download" />
         </Dropdown>,

--- a/src/components/GalleryCard/index.tsx
+++ b/src/components/GalleryCard/index.tsx
@@ -57,9 +57,10 @@ const GalleryCard: React.SFC<GalleryCardProps> = (props) => {
             3D
         </Button>,
         <Tooltip key={`${props.cellID}-download`} title={hasDownload?null:NO_DOWNLOADS_TOOLTIP}>
-        <Dropdown  overlay={menu} trigger={["click"]}>
-            <Button icon="download" />
-        </Dropdown></Tooltip>,
+            <Dropdown  overlay={menu} trigger={["click"]}>
+                <Button icon="download" />
+            </Dropdown>
+        </Tooltip>,
         <Button onClick={deselectPoint} key={`${props.cellID}-close`}>
             <Icon type="close" />
         </Button>,

--- a/src/components/GalleryCard/index.tsx
+++ b/src/components/GalleryCard/index.tsx
@@ -1,7 +1,8 @@
-import { Avatar, Button, Card, Dropdown, Icon, List, Menu } from "antd";
+import { Avatar, Button, Card, Dropdown, Icon, List, Menu, Tooltip } from "antd";
 import React from "react";
 
 import { DeselectPointAction, SelectPointAction } from "../../state/selection/types";
+import { NO_DOWNLOADS_TOOLTIP } from "../../constants";
 
 import styles from "./style.css";
 
@@ -46,7 +47,7 @@ const GalleryCard: React.SFC<GalleryCardProps> = (props) => {
             )}
         </Menu>
     );
-
+    const hasDownload = (props.downloadHref !== "" || props.downloadFullField !== "");
     const actions = [
         <Button
             className={props.selected ? styles.disabled : ""}
@@ -55,10 +56,10 @@ const GalleryCard: React.SFC<GalleryCardProps> = (props) => {
         >
             3D
         </Button>,
-        (props.downloadHref !== "" || props.downloadFullField !== "") &&
-        <Dropdown key={`${props.cellID}-download`} overlay={menu} trigger={["click"]}>
+        <Tooltip key={`${props.cellID}-download`} title={hasDownload?null:NO_DOWNLOADS_TOOLTIP}>
+        <Dropdown  overlay={menu} trigger={["click"]}>
             <Button icon="download" />
-        </Dropdown>,
+        </Dropdown></Tooltip>,
         <Button onClick={deselectPoint} key={`${props.cellID}-close`}>
             <Icon type="close" />
         </Button>,

--- a/src/components/InteractiveLegend/index.tsx
+++ b/src/components/InteractiveLegend/index.tsx
@@ -14,6 +14,7 @@ interface InteractiveLegendProps {
     handleDownload: (key: string) => void;
     downloadUrls: string[];
     downloadConfig: DownloadConfig;
+    downloadRoot: string;
     onBarClicked?: (clicked: CheckboxChangeEvent) => void;
     handleCloseSelectionSet?: (id: number | string) => void;
 }
@@ -26,6 +27,7 @@ const InteractiveLegend: React.FunctionComponent<InteractiveLegendProps> = (prop
         handleCloseSelectionSet,
         handleDownload,
         downloadConfig,
+        downloadRoot,
         hideable,
         onBarClicked,
         panelData,
@@ -50,6 +52,7 @@ const InteractiveLegend: React.FunctionComponent<InteractiveLegendProps> = (prop
                         handleDownload={handleDownload}
                         downloadUrls={downloadUrls}
                         downloadConfig={downloadConfig}
+                        downloadRoot={downloadRoot}
                     />
                 );
             })}

--- a/src/components/InteractiveRow/index.tsx
+++ b/src/components/InteractiveRow/index.tsx
@@ -18,6 +18,7 @@ interface InteractiveRowProps {
     showTooltips: boolean;
     downloadConfig: DownloadConfig;
     downloadUrls: string[];
+    downloadRoot: string;
     hideable?: boolean;
     onBarClicked?: (clickEvent: CheckboxChangeEvent) => void;
     handleClose?: (id: number | string) => void;
@@ -56,6 +57,7 @@ export default class InteractiveRow extends React.Component<InteractiveRowProps>
             checked,
             downloadUrls,
             downloadConfig,
+            downloadRoot,
             handleDownload,
         } = this.props;
 
@@ -103,6 +105,7 @@ export default class InteractiveRow extends React.Component<InteractiveRowProps>
                         total={total}
                         downloadConfig={downloadConfig}
                         downloadUrls={downloadUrls}
+                        downloadRoot={downloadRoot}
                         handleDownload={handleDownload}
                     />
                     {closeable && (

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -71,3 +71,5 @@ export const GENERAL_PLOT_SETTINGS = {
     textColor: "rgb(255,255,255)",
     unselectedCircleOpacity: 0.5,
 };
+
+export const NO_DOWNLOADS_TOOLTIP = "Direct download is not available for this dataset.";

--- a/src/containers/Cfe/test/selectors.test.ts
+++ b/src/containers/Cfe/test/selectors.test.ts
@@ -50,9 +50,9 @@ describe("Viewer selectors", () => {
             expect(result).to.deep.equal({
                 cellId: "1",
                 baseUrl: "url/",
-                cellDownloadHref: "&id=C1",
+                cellDownloadHref: "dlurl/&id=C1",
                 cellPath: "volumeviewerPath",
-                fovDownloadHref: "&id=F12762",
+                fovDownloadHref: "dlurl/&id=F12762",
                 fovPath: "fovVolumeviewerPath",
                 viewerChannelSettings: {},
                 transform: undefined,
@@ -71,7 +71,7 @@ describe("Viewer selectors", () => {
             expect(result).to.deep.equal({
                 cellId: "12762",
                 baseUrl: "url/",
-                cellDownloadHref: "&id=F12762",
+                cellDownloadHref: "dlurl/&id=F12762",
                 cellPath: "fovVolumeviewerPath",
                 fovDownloadHref: "",
                 fovPath: "",

--- a/src/containers/ColorByMenu/index.tsx
+++ b/src/containers/ColorByMenu/index.tsx
@@ -17,7 +17,7 @@ import {
 import metadataStateBranch from "../../state/metadata";
 import { MappingOfMeasuredValuesArrays, MeasuredFeatureDef } from "../../state/metadata/types";
 import selectionStateBranch from "../../state/selection";
-import { getFeatureDefTooltip } from "../../state/selection/selectors";
+import { getFeatureDefTooltip, getDownloadRoot } from "../../state/selection/selectors";
 
 import {
     BoolToggleAction,
@@ -52,6 +52,7 @@ interface PropsFromState {
     colorBy: keyof MappingOfMeasuredValuesArrays;
     downloadUrls: string[];
     downloadConfig: DownloadConfig;
+    downloadRoot: string;
     filtersToExclude: string[];
     interactivePanelData: PanelData[];
     selectionSetsPanelData: PanelData[];
@@ -138,6 +139,7 @@ class ColorByMenu extends React.Component<ColorByMenuProps> {
         const {
             downloadUrls,
             downloadConfig,
+            downloadRoot,
             handleApplyColorSwitchChange,
             selectionSetsPanelData,
             handleCloseSelectionSet,
@@ -164,6 +166,7 @@ class ColorByMenu extends React.Component<ColorByMenuProps> {
                         panelData={selectionSetsPanelData}
                         downloadUrls={downloadUrls}
                         downloadConfig={downloadConfig}
+                        downloadRoot={downloadRoot}
                         handleDownload={this.onSelectionSetDownloadButtonClicked}
                     />
                 </div>
@@ -178,6 +181,7 @@ class ColorByMenu extends React.Component<ColorByMenuProps> {
             interactivePanelData,
             downloadUrls,
             downloadConfig,
+            downloadRoot,
             colorBy,
             colorByMenuOptions,
             handleChangeAxis,
@@ -235,6 +239,7 @@ class ColorByMenu extends React.Component<ColorByMenuProps> {
                         panelData={interactivePanelData}
                         downloadUrls={downloadUrls}
                         downloadConfig={downloadConfig}
+                        downloadRoot={downloadRoot}
                         hideable={true}
                         onBarClicked={this.onBarClicked}
                         handleDownload={this.onCategorySetDownloadButtonClicked}
@@ -272,6 +277,7 @@ function mapStateToProps(state: State): PropsFromState {
         categoricalFeatures: metadataStateBranch.selectors.getCategoricalFeatureKeys(state),
         downloadConfig: selectionStateBranch.selectors.getDownloadConfig(state),
         downloadUrls: createUrlFromListOfIds(state),
+        downloadRoot: getDownloadRoot(state),
         filtersToExclude: selectionStateBranch.selectors.getFiltersToExclude(state),
         groupByTitle: getGroupByTitle(state),
         interactivePanelData: getInteractivePanelData(state),

--- a/src/containers/ColorByMenu/selectors.ts
+++ b/src/containers/ColorByMenu/selectors.ts
@@ -200,6 +200,9 @@ export const getListOfCellIdsByDownloadConfig = createSelector(
 export const createUrlFromListOfIds = createSelector(
     [getDownloadRoot, getListOfCellIdsByDownloadConfig],
     (downloadRoot: string, cellIdsToDownload): string[] => {
+        if (downloadRoot === "") {
+            return [];
+        }
         const chunkSize = 300;
         const chunksOfIds = chunk(cellIdsToDownload, chunkSize);
         return map(

--- a/src/state/test/mocks.ts
+++ b/src/state/test/mocks.ts
@@ -173,6 +173,7 @@ export const mockState = {
             key: "",
             type: "",
         },
+        downloadRoot: "dlurl/",
         groupBy: INITIAL_COLOR_AND_GROUP_BY,
         filterExclude: [],
         plotByOnX: "apical-proximity",

--- a/src/state/util.ts
+++ b/src/state/util.ts
@@ -73,7 +73,8 @@ export function convertSingleImageIdToDownloadId(id: string): string {
 }
 
 export function formatDownloadOfIndividualFile(root: string, id: string): string {
-    return `${root}&id=${id}`;
+    // if no downloadRoot is present, then return empty string
+    return root === "" ? "" : `${root}&id=${id}`;
 }
 
 export function formatThumbnailSrc(thumbnailRoot: string, item: FileInfo): string {


### PR DESCRIPTION
Problem
=======
Dataset without a downloadRoot shows download buttons that have invalid urls. When clicked, they show ugly error messages.

Solution
========
Disable all download buttons if downloadRoot is not provided for a dataset

## Type of change

* New feature (non-breaking change which adds functionality)

To test:
```
npm run start:dev-db
```
select "Drug dataset 0.1"

all download buttons should be disabled with tooltips saying that download is not allowed for this dataset.  Compare with any other dataset which should be providing such buttons and allowing download.

Future work: can we enable download of zarr datasets via simple web links?