### PR TITLE
make userData optional

### DIFF
--- a/src/components/DatasetCard/index.tsx
+++ b/src/components/DatasetCard/index.tsx
@@ -67,15 +67,15 @@ const DatasetCard: React.FunctionComponent<DatasetCardProps> = ({
             {/* Spacer div to push `Descriptions` to the bottom of the card */}
             <div className={styles.spacer}/>
             <Descriptions column={1} size="small">
-                <Descriptions.Item label="Number of Cells">
+                {userData.totalCells && <Descriptions.Item label="Number of Cells">
                     {userData.totalCells.toLocaleString("en")}
-                </Descriptions.Item>
-                <Descriptions.Item label="Number of FOVs">
+                </Descriptions.Item>}
+                {userData.totalFOVs && <Descriptions.Item label="Number of FOVs">
                     {userData.totalFOVs.toLocaleString("en")}
-                </Descriptions.Item>
-                <Descriptions.Item label="Number of tagged structures">
+                </Descriptions.Item>}
+                {userData.totalTaggedStructures && <Descriptions.Item label="Number of tagged structures">
                     {userData.totalTaggedStructures}
-                </Descriptions.Item>
+                </Descriptions.Item>}
             </Descriptions>
             <Button type="primary" className={styles.loadButton}>
                 Load


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
we decided to make `userData` optional in cell feature explore instead of making it required in cell feature data.
When `totalCells` or `totalFOVs` is 0 or not given, the label and value will both be hidden on the app.

Solution
========
- make each item in `userData` optional in `src/components/DatasetCard/index.tsx`

with @meganrm @frasercl 

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

Screenshots (optional):
-----------------------
<img width="1644" alt="Screenshot 2023-05-10 at 1 47 03 PM" src="https://github.com/allen-cell-animated/cell-feature-explorer/assets/91452427/acbd3de7-7d64-4e15-91b1-01e69f5eec93">

