### PR TITLE
update viewer to 2.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "ISC",
             "dependencies": {
                 "@aics/browsing-context-messaging": "~1.1",
-                "@aics/web-3d-viewer": "^2.7.2",
+                "@aics/web-3d-viewer": "^2.7.3",
                 "@ant-design/icons": "^4.2.2",
                 "antd": "^3.26.20",
                 "axios": "^0.21.1",
@@ -119,9 +119,9 @@
             }
         },
         "node_modules/@aics/web-3d-viewer": {
-            "version": "2.7.2",
-            "resolved": "https://registry.npmjs.org/@aics/web-3d-viewer/-/web-3d-viewer-2.7.2.tgz",
-            "integrity": "sha512-0Jxxt0dPNpiK4+uChFhuysez4mBdFKyWCI8BMbnPVuCg/iziuBMQPJPIri2YUO+GCBMPxEXtV7ENqtAtz3A6aw==",
+            "version": "2.7.3",
+            "resolved": "https://registry.npmjs.org/@aics/web-3d-viewer/-/web-3d-viewer-2.7.3.tgz",
+            "integrity": "sha512-YEj0z2S+5fgNEdtxJu+TYnZ8PI198OAxnr/2sAR83SJfh0vd8ifwGxasb2t1VQgNYJIKNWFoDvERG8P/ap30iQ==",
             "dependencies": {
                 "@aics/volume-viewer": "^3.5.3",
                 "color-string": "^1.5.3",
@@ -18720,9 +18720,9 @@
             }
         },
         "@aics/web-3d-viewer": {
-            "version": "2.7.2",
-            "resolved": "https://registry.npmjs.org/@aics/web-3d-viewer/-/web-3d-viewer-2.7.2.tgz",
-            "integrity": "sha512-0Jxxt0dPNpiK4+uChFhuysez4mBdFKyWCI8BMbnPVuCg/iziuBMQPJPIri2YUO+GCBMPxEXtV7ENqtAtz3A6aw==",
+            "version": "2.7.3",
+            "resolved": "https://registry.npmjs.org/@aics/web-3d-viewer/-/web-3d-viewer-2.7.3.tgz",
+            "integrity": "sha512-YEj0z2S+5fgNEdtxJu+TYnZ8PI198OAxnr/2sAR83SJfh0vd8ifwGxasb2t1VQgNYJIKNWFoDvERG8P/ap30iQ==",
             "requires": {
                 "@aics/volume-viewer": "^3.5.3",
                 "color-string": "^1.5.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "ISC",
             "dependencies": {
                 "@aics/browsing-context-messaging": "~1.1",
-                "@aics/web-3d-viewer": "^2.6.2",
+                "@aics/web-3d-viewer": "^2.7.2",
                 "@ant-design/icons": "^4.2.2",
                 "antd": "^3.26.20",
                 "axios": "^0.21.1",
@@ -108,21 +108,22 @@
             "integrity": "sha512-ts+Z8g/xTJaD+g9fAElEJbclk1L0xDsHy6ioq9N5T4j5WPew46WvZ/794Vxnn9N06KyjkCO6zc4JEl7ZZRSa5Q=="
         },
         "node_modules/@aics/volume-viewer": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/@aics/volume-viewer/-/volume-viewer-3.2.1.tgz",
-            "integrity": "sha512-x3frrJdVCxqQG88lc86u2JNeTNspa4Aiq8Uo8wXXMJZEdfWs817M2zfNiHfD5F2P5IxLKz6q6Jx5SbXKYe0gCQ==",
+            "version": "3.5.3",
+            "resolved": "https://registry.npmjs.org/@aics/volume-viewer/-/volume-viewer-3.5.3.tgz",
+            "integrity": "sha512-MmYW34eRZN9OHTSEWlNRBE1XZB5ddtEc1ueJEStaKPASJ8DO4O3bicsCLMIZeC5M0BxleK+pINzZfjgRuePKXQ==",
             "dependencies": {
                 "geotiff": "^2.0.5",
                 "three": "^0.144.0",
-                "zarr": "^0.5.2"
+                "tweakpane": "^3.1.9",
+                "zarrita": "^0.3.2"
             }
         },
         "node_modules/@aics/web-3d-viewer": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/@aics/web-3d-viewer/-/web-3d-viewer-2.6.2.tgz",
-            "integrity": "sha512-7mzJbleeGaTLTo1T07emE6cMSJsUNhhnl/5lZUcqomgdg/lLrEg9QdmCGKMD/JTDdG8RIHHyDuTqU06PiS6rJw==",
+            "version": "2.7.2",
+            "resolved": "https://registry.npmjs.org/@aics/web-3d-viewer/-/web-3d-viewer-2.7.2.tgz",
+            "integrity": "sha512-0Jxxt0dPNpiK4+uChFhuysez4mBdFKyWCI8BMbnPVuCg/iziuBMQPJPIri2YUO+GCBMPxEXtV7ENqtAtz3A6aw==",
             "dependencies": {
-                "@aics/volume-viewer": "^3.2.1",
+                "@aics/volume-viewer": "^3.5.3",
                 "color-string": "^1.5.3",
                 "d3": "^4.11.0",
                 "lodash": "^4.17.20",
@@ -2780,9 +2781,9 @@
             }
         },
         "node_modules/@petamoriken/float16": {
-            "version": "3.8.1",
-            "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.8.1.tgz",
-            "integrity": "sha512-oj3dU9kuMy8AqrreIboVh3KCJGSQO5T+dJ8JQFl369961jTWvPLP1GIlLy0FVoWehXLoI9BXygu/yzuNiIHBlg=="
+            "version": "3.8.4",
+            "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.8.4.tgz",
+            "integrity": "sha512-kB+NJ5Br56ZhElKsf0pM7/PQfrDdDVMRz8f0JM6eVOGE+L89z9hwcst9QvWBBnazzuqGTGtPsJNZoQ1JdNiGSQ=="
         },
         "node_modules/@plotly/d3-sankey": {
             "version": "0.7.2",
@@ -3916,6 +3917,40 @@
             "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
             "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
             "dev": true
+        },
+        "node_modules/@zarrita/core": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/@zarrita/core/-/core-0.0.3.tgz",
+            "integrity": "sha512-fWv51b+xbYnws1pkNDPwJQoDa76aojxplHyMup82u11UAiet3gURMsrrkhM6YbeTgSY1A8oGxDOrvar3SiZpLA==",
+            "dependencies": {
+                "@zarrita/storage": "^0.0.2",
+                "@zarrita/typedarray": "^0.0.1",
+                "numcodecs": "^0.2.2"
+            }
+        },
+        "node_modules/@zarrita/indexing": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/@zarrita/indexing/-/indexing-0.0.3.tgz",
+            "integrity": "sha512-Q61d9MYX6dsK1DLltEpwx4mJWCZHj0TXiaEN4QpxNDtToa/EoyytP/pYHPypO4GXBscZooJ6eZkKT5FMx9PVfg==",
+            "dependencies": {
+                "@zarrita/core": "^0.0.3",
+                "@zarrita/storage": "^0.0.2",
+                "@zarrita/typedarray": "^0.0.1"
+            }
+        },
+        "node_modules/@zarrita/storage": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/@zarrita/storage/-/storage-0.0.2.tgz",
+            "integrity": "sha512-uFt4abAoiOYLroalNDAnVaQxA17zGKrQ0waYKmTVm+bNonz8ggKZP+0FqMhgUZITGChqoANHuYTazbuU5AFXWA==",
+            "dependencies": {
+                "reference-spec-reader": "^0.2.0",
+                "unzipit": "^1.3.6"
+            }
+        },
+        "node_modules/@zarrita/typedarray": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/@zarrita/typedarray/-/typedarray-0.0.1.tgz",
+            "integrity": "sha512-ZdvNjYP1bEuQXoSTVkemV99w42jHYrJ3nh9golCLd4MVBlrVbfZo4wWgBslU4JZUaDikhFSH+GWMDgAq/rI32g=="
         },
         "node_modules/3d-view": {
             "version": "2.0.1",
@@ -7557,7 +7592,8 @@
         "node_modules/eventemitter3": {
             "version": "4.0.7",
             "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-            "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+            "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+            "dev": true
         },
         "node_modules/eventlistener": {
             "version": "0.0.1",
@@ -8412,9 +8448,9 @@
             "integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg=="
         },
         "node_modules/geotiff": {
-            "version": "2.0.7",
-            "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.0.7.tgz",
-            "integrity": "sha512-FKvFTNowMU5K6lHYY2f83d4lS2rsCNdpUC28AX61x9ZzzqPNaWFElWv93xj0eJFaNyOYA63ic5OzJ88dHpoA5Q==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.1.0.tgz",
+            "integrity": "sha512-B/iFJuFfRpmPHXf8aIRPRgUWwfaNb6dlsynkM8SWeHAPu7CpyvfqEa43KlBt7xxq5OTVysQacFHxhCn3SZhRKQ==",
             "dependencies": {
                 "@petamoriken/float16": "^3.4.7",
                 "lerc": "^3.0.0",
@@ -8422,7 +8458,8 @@
                 "parse-headers": "^2.0.2",
                 "quick-lru": "^6.1.1",
                 "web-worker": "^1.2.0",
-                "xml-utils": "^1.0.2"
+                "xml-utils": "^1.0.2",
+                "zstddec": "^0.1.0"
             },
             "engines": {
                 "node": ">=10.19"
@@ -12117,21 +12154,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/p-queue": {
-            "version": "7.3.4",
-            "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.3.4.tgz",
-            "integrity": "sha512-esox8CWt0j9EZECFvkFl2WNPat8LN4t7WWeXq73D9ha0V96qPRufApZi4ZhPwXAln1uVVal429HVVKPa2X0yQg==",
-            "dependencies": {
-                "eventemitter3": "^4.0.7",
-                "p-timeout": "^5.0.2"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/p-retry": {
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
@@ -12143,17 +12165,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/p-timeout": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
-            "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/p-try": {
@@ -14293,9 +14304,9 @@
             ]
         },
         "node_modules/quick-lru": {
-            "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.1.tgz",
-            "integrity": "sha512-S27GBT+F0NTRiehtbrgaSE1idUAJ5bX8dPAQTdylEyNlrdcH5X4Lz7Edz3DYzecbsCluD5zO8ZNEe04z3D3u6Q==",
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.2.tgz",
+            "integrity": "sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ==",
             "engines": {
                 "node": ">=12"
             },
@@ -15333,6 +15344,11 @@
             "peerDependencies": {
                 "redux": ">=3.5.2"
             }
+        },
+        "node_modules/reference-spec-reader": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/reference-spec-reader/-/reference-spec-reader-0.2.0.tgz",
+            "integrity": "sha512-q0mfCi5yZSSHXpCyxjgQeaORq3tvDsxDyzaadA/5+AbAUwRyRuuTh0aRQuE/vAOt/qzzxidJ5iDeu1cLHaNBlQ=="
         },
         "node_modules/regenerate": {
             "version": "1.4.2",
@@ -17376,6 +17392,14 @@
                 "gl-vec3": "^1.0.2"
             }
         },
+        "node_modules/tweakpane": {
+            "version": "3.1.10",
+            "resolved": "https://registry.npmjs.org/tweakpane/-/tweakpane-3.1.10.tgz",
+            "integrity": "sha512-rqwnl/pUa7+inhI2E9ayGTqqP0EPOOn/wVvSWjZsRbZUItzNShny7pzwL3hVlaN4m9t/aZhsP0aFQ9U5VVR2VQ==",
+            "funding": {
+                "url": "https://github.com/sponsors/cocopon"
+            }
+        },
         "node_modules/tweetnacl": {
             "version": "0.14.5",
             "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
@@ -17609,6 +17633,17 @@
             "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
             "integrity": "sha512-vRCqFv6UhXpWxZPyGDh/F3ZpNv8/qo7w6iufLpQg9aKnQ71qM4B5KiI7Mia9COcjEhrO9LueHpMYjYzsWH3OIg=="
         },
+        "node_modules/unzipit": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/unzipit/-/unzipit-1.4.3.tgz",
+            "integrity": "sha512-gsq2PdJIWWGhx5kcdWStvNWit9FVdTewm4SEG7gFskWs+XCVaULt9+BwuoBtJiRE8eo3L1IPAOrbByNLtLtIlg==",
+            "dependencies": {
+                "uzip-module": "^1.0.2"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/update-browserslist-db": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
@@ -17726,6 +17761,11 @@
             "bin": {
                 "uuid": "dist/bin/uuid"
             }
+        },
+        "node_modules/uzip-module": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/uzip-module/-/uzip-module-1.0.3.tgz",
+            "integrity": "sha512-AMqwWZaknLM77G+VPYNZLEruMGWGzyigPK3/Whg99B3S6vGHuqsyl5ZrOv1UUF3paGK1U6PM0cnayioaryg/fA=="
         },
         "node_modules/v8-compile-cache-lib": {
             "version": "3.0.1",
@@ -18632,16 +18672,14 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/zarr": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/zarr/-/zarr-0.5.2.tgz",
-            "integrity": "sha512-XiAZTlkCTALZyXCAXY2rgfRY45sIaGZd/rKKuQa84+bjpxoyNYXbAU5uaIDTR+CvIuTFABqq8Gc4PfzZHYOvkw==",
+        "node_modules/zarrita": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/zarrita/-/zarrita-0.3.2.tgz",
+            "integrity": "sha512-Zx9nS28C2tXZhF1BmQkgQGi0M/Z5JiM/KCMa+fEYtr/MnIzyizR4sKRA/sXjDP1iuylILWTJAWWBJD//0ONXCA==",
             "dependencies": {
-                "numcodecs": "^0.2.2",
-                "p-queue": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=12"
+                "@zarrita/core": "^0.0.3",
+                "@zarrita/indexing": "^0.0.3",
+                "@zarrita/storage": "^0.0.2"
             }
         },
         "node_modules/zero-crossings": {
@@ -18651,6 +18689,11 @@
             "dependencies": {
                 "cwise-compiler": "^1.0.0"
             }
+        },
+        "node_modules/zstddec": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.1.0.tgz",
+            "integrity": "sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg=="
         }
     },
     "dependencies": {
@@ -18666,21 +18709,22 @@
             "integrity": "sha512-ts+Z8g/xTJaD+g9fAElEJbclk1L0xDsHy6ioq9N5T4j5WPew46WvZ/794Vxnn9N06KyjkCO6zc4JEl7ZZRSa5Q=="
         },
         "@aics/volume-viewer": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/@aics/volume-viewer/-/volume-viewer-3.2.1.tgz",
-            "integrity": "sha512-x3frrJdVCxqQG88lc86u2JNeTNspa4Aiq8Uo8wXXMJZEdfWs817M2zfNiHfD5F2P5IxLKz6q6Jx5SbXKYe0gCQ==",
+            "version": "3.5.3",
+            "resolved": "https://registry.npmjs.org/@aics/volume-viewer/-/volume-viewer-3.5.3.tgz",
+            "integrity": "sha512-MmYW34eRZN9OHTSEWlNRBE1XZB5ddtEc1ueJEStaKPASJ8DO4O3bicsCLMIZeC5M0BxleK+pINzZfjgRuePKXQ==",
             "requires": {
                 "geotiff": "^2.0.5",
                 "three": "^0.144.0",
-                "zarr": "^0.5.2"
+                "tweakpane": "^3.1.9",
+                "zarrita": "^0.3.2"
             }
         },
         "@aics/web-3d-viewer": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/@aics/web-3d-viewer/-/web-3d-viewer-2.6.2.tgz",
-            "integrity": "sha512-7mzJbleeGaTLTo1T07emE6cMSJsUNhhnl/5lZUcqomgdg/lLrEg9QdmCGKMD/JTDdG8RIHHyDuTqU06PiS6rJw==",
+            "version": "2.7.2",
+            "resolved": "https://registry.npmjs.org/@aics/web-3d-viewer/-/web-3d-viewer-2.7.2.tgz",
+            "integrity": "sha512-0Jxxt0dPNpiK4+uChFhuysez4mBdFKyWCI8BMbnPVuCg/iziuBMQPJPIri2YUO+GCBMPxEXtV7ENqtAtz3A6aw==",
             "requires": {
-                "@aics/volume-viewer": "^3.2.1",
+                "@aics/volume-viewer": "^3.5.3",
                 "color-string": "^1.5.3",
                 "d3": "^4.11.0",
                 "lodash": "^4.17.20",
@@ -20587,9 +20631,9 @@
             }
         },
         "@petamoriken/float16": {
-            "version": "3.8.1",
-            "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.8.1.tgz",
-            "integrity": "sha512-oj3dU9kuMy8AqrreIboVh3KCJGSQO5T+dJ8JQFl369961jTWvPLP1GIlLy0FVoWehXLoI9BXygu/yzuNiIHBlg=="
+            "version": "3.8.4",
+            "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.8.4.tgz",
+            "integrity": "sha512-kB+NJ5Br56ZhElKsf0pM7/PQfrDdDVMRz8f0JM6eVOGE+L89z9hwcst9QvWBBnazzuqGTGtPsJNZoQ1JdNiGSQ=="
         },
         "@plotly/d3-sankey": {
             "version": "0.7.2",
@@ -21582,6 +21626,40 @@
             "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
             "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
             "dev": true
+        },
+        "@zarrita/core": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/@zarrita/core/-/core-0.0.3.tgz",
+            "integrity": "sha512-fWv51b+xbYnws1pkNDPwJQoDa76aojxplHyMup82u11UAiet3gURMsrrkhM6YbeTgSY1A8oGxDOrvar3SiZpLA==",
+            "requires": {
+                "@zarrita/storage": "^0.0.2",
+                "@zarrita/typedarray": "^0.0.1",
+                "numcodecs": "^0.2.2"
+            }
+        },
+        "@zarrita/indexing": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/@zarrita/indexing/-/indexing-0.0.3.tgz",
+            "integrity": "sha512-Q61d9MYX6dsK1DLltEpwx4mJWCZHj0TXiaEN4QpxNDtToa/EoyytP/pYHPypO4GXBscZooJ6eZkKT5FMx9PVfg==",
+            "requires": {
+                "@zarrita/core": "^0.0.3",
+                "@zarrita/storage": "^0.0.2",
+                "@zarrita/typedarray": "^0.0.1"
+            }
+        },
+        "@zarrita/storage": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/@zarrita/storage/-/storage-0.0.2.tgz",
+            "integrity": "sha512-uFt4abAoiOYLroalNDAnVaQxA17zGKrQ0waYKmTVm+bNonz8ggKZP+0FqMhgUZITGChqoANHuYTazbuU5AFXWA==",
+            "requires": {
+                "reference-spec-reader": "^0.2.0",
+                "unzipit": "^1.3.6"
+            }
+        },
+        "@zarrita/typedarray": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/@zarrita/typedarray/-/typedarray-0.0.1.tgz",
+            "integrity": "sha512-ZdvNjYP1bEuQXoSTVkemV99w42jHYrJ3nh9golCLd4MVBlrVbfZo4wWgBslU4JZUaDikhFSH+GWMDgAq/rI32g=="
         },
         "3d-view": {
             "version": "2.0.1",
@@ -24571,7 +24649,8 @@
         "eventemitter3": {
             "version": "4.0.7",
             "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-            "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+            "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+            "dev": true
         },
         "eventlistener": {
             "version": "0.0.1",
@@ -25240,9 +25319,9 @@
             "integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg=="
         },
         "geotiff": {
-            "version": "2.0.7",
-            "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.0.7.tgz",
-            "integrity": "sha512-FKvFTNowMU5K6lHYY2f83d4lS2rsCNdpUC28AX61x9ZzzqPNaWFElWv93xj0eJFaNyOYA63ic5OzJ88dHpoA5Q==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.1.0.tgz",
+            "integrity": "sha512-B/iFJuFfRpmPHXf8aIRPRgUWwfaNb6dlsynkM8SWeHAPu7CpyvfqEa43KlBt7xxq5OTVysQacFHxhCn3SZhRKQ==",
             "requires": {
                 "@petamoriken/float16": "^3.4.7",
                 "lerc": "^3.0.0",
@@ -25250,7 +25329,8 @@
                 "parse-headers": "^2.0.2",
                 "quick-lru": "^6.1.1",
                 "web-worker": "^1.2.0",
-                "xml-utils": "^1.0.2"
+                "xml-utils": "^1.0.2",
+                "zstddec": "^0.1.0"
             }
         },
         "get-caller-file": {
@@ -28254,15 +28334,6 @@
             "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
             "dev": true
         },
-        "p-queue": {
-            "version": "7.3.4",
-            "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.3.4.tgz",
-            "integrity": "sha512-esox8CWt0j9EZECFvkFl2WNPat8LN4t7WWeXq73D9ha0V96qPRufApZi4ZhPwXAln1uVVal429HVVKPa2X0yQg==",
-            "requires": {
-                "eventemitter3": "^4.0.7",
-                "p-timeout": "^5.0.2"
-            }
-        },
         "p-retry": {
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
@@ -28272,11 +28343,6 @@
                 "@types/retry": "0.12.0",
                 "retry": "^0.13.1"
             }
-        },
-        "p-timeout": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
-            "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew=="
         },
         "p-try": {
             "version": "2.2.0",
@@ -29972,9 +30038,9 @@
             "dev": true
         },
         "quick-lru": {
-            "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.1.tgz",
-            "integrity": "sha512-S27GBT+F0NTRiehtbrgaSE1idUAJ5bX8dPAQTdylEyNlrdcH5X4Lz7Edz3DYzecbsCluD5zO8ZNEe04z3D3u6Q=="
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.2.tgz",
+            "integrity": "sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ=="
         },
         "quickselect": {
             "version": "2.0.0",
@@ -30962,6 +31028,11 @@
                 "rxjs": "^5.5.11",
                 "symbol-observable": "^1.2.0"
             }
+        },
+        "reference-spec-reader": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/reference-spec-reader/-/reference-spec-reader-0.2.0.tgz",
+            "integrity": "sha512-q0mfCi5yZSSHXpCyxjgQeaORq3tvDsxDyzaadA/5+AbAUwRyRuuTh0aRQuE/vAOt/qzzxidJ5iDeu1cLHaNBlQ=="
         },
         "regenerate": {
             "version": "1.4.2",
@@ -32631,6 +32702,11 @@
                 "gl-vec3": "^1.0.2"
             }
         },
+        "tweakpane": {
+            "version": "3.1.10",
+            "resolved": "https://registry.npmjs.org/tweakpane/-/tweakpane-3.1.10.tgz",
+            "integrity": "sha512-rqwnl/pUa7+inhI2E9ayGTqqP0EPOOn/wVvSWjZsRbZUItzNShny7pzwL3hVlaN4m9t/aZhsP0aFQ9U5VVR2VQ=="
+        },
         "tweetnacl": {
             "version": "0.14.5",
             "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
@@ -32799,6 +32875,14 @@
             "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
             "integrity": "sha512-vRCqFv6UhXpWxZPyGDh/F3ZpNv8/qo7w6iufLpQg9aKnQ71qM4B5KiI7Mia9COcjEhrO9LueHpMYjYzsWH3OIg=="
         },
+        "unzipit": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/unzipit/-/unzipit-1.4.3.tgz",
+            "integrity": "sha512-gsq2PdJIWWGhx5kcdWStvNWit9FVdTewm4SEG7gFskWs+XCVaULt9+BwuoBtJiRE8eo3L1IPAOrbByNLtLtIlg==",
+            "requires": {
+                "uzip-module": "^1.0.2"
+            }
+        },
         "update-browserslist-db": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
@@ -32869,6 +32953,11 @@
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
             "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
             "dev": true
+        },
+        "uzip-module": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/uzip-module/-/uzip-module-1.0.3.tgz",
+            "integrity": "sha512-AMqwWZaknLM77G+VPYNZLEruMGWGzyigPK3/Whg99B3S6vGHuqsyl5ZrOv1UUF3paGK1U6PM0cnayioaryg/fA=="
         },
         "v8-compile-cache-lib": {
             "version": "3.0.1",
@@ -33529,13 +33618,14 @@
             "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
             "dev": true
         },
-        "zarr": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/zarr/-/zarr-0.5.2.tgz",
-            "integrity": "sha512-XiAZTlkCTALZyXCAXY2rgfRY45sIaGZd/rKKuQa84+bjpxoyNYXbAU5uaIDTR+CvIuTFABqq8Gc4PfzZHYOvkw==",
+        "zarrita": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/zarrita/-/zarrita-0.3.2.tgz",
+            "integrity": "sha512-Zx9nS28C2tXZhF1BmQkgQGi0M/Z5JiM/KCMa+fEYtr/MnIzyizR4sKRA/sXjDP1iuylILWTJAWWBJD//0ONXCA==",
             "requires": {
-                "numcodecs": "^0.2.2",
-                "p-queue": "^7.1.0"
+                "@zarrita/core": "^0.0.3",
+                "@zarrita/indexing": "^0.0.3",
+                "@zarrita/storage": "^0.0.2"
             }
         },
         "zero-crossings": {
@@ -33545,6 +33635,11 @@
             "requires": {
                 "cwise-compiler": "^1.0.0"
             }
+        },
+        "zstddec": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.1.0.tgz",
+            "integrity": "sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg=="
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     },
     "dependencies": {
         "@aics/browsing-context-messaging": "~1.1",
-        "@aics/web-3d-viewer": "^2.7.2",
+        "@aics/web-3d-viewer": "^2.7.3",
         "@ant-design/icons": "^4.2.2",
         "antd": "^3.26.20",
         "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     },
     "dependencies": {
         "@aics/browsing-context-messaging": "~1.1",
-        "@aics/web-3d-viewer": "^2.6.2",
+        "@aics/web-3d-viewer": "^2.7.2",
         "@ant-design/icons": "^4.2.2",
         "antd": "^3.26.20",
         "axios": "^0.21.1",


### PR DESCRIPTION
This introduces several new 3d viewer features into CFE.

In particular:
1. The "info panel" now arrives.  All measured feature values are propagated from CFE into a displayable panel in the 3d viewer, along with some general metadata like image dimensions.
2. 2D modes now default to "middle slice" instead of single slice, and they render at higher quality than previously.
3. if the images are provided as Zarr, then the viewer attempts to display a higher resolution in XY slice mode.  This can result in slower performance but greater image quality and detail.  This mode will receive several optimizations in coming weeks/months.  
