### PR TITLE
consistency around non required fields

### DIFF
--- a/src/state/image-dataset/firebase/index.ts
+++ b/src/state/image-dataset/firebase/index.ts
@@ -134,7 +134,9 @@ class FirebaseRequest implements ImageDataset {
         if (this.viewerChannelSettings) {
             return Promise.resolve(this.viewerChannelSettings);
         }
-
+        if (!this.viewerSettingsPath) { 
+            return Promise.resolve({} as ViewerChannelSettings);
+        }
         return axios
             .get(this.viewerSettingsPath)
             .then((metadata: AxiosResponse) => metadata.data)

--- a/src/state/image-dataset/types.ts
+++ b/src/state/image-dataset/types.ts
@@ -21,17 +21,17 @@ export interface DatasetMetaData {
     version: string;
     id: string;
     description: string;
-    image: string;
+    image?: string;
     index: number;
     link?: string;
     manifest?: string;
     production?: boolean;
     userData: {
-        isNew: boolean;
-        inReview: boolean;
-        totalTaggedStructures: number;
-        totalCells: number;
-        totalFOVs: number;
+        isNew?: boolean;
+        inReview?: boolean;
+        totalTaggedStructures?: number;
+        totalCells?: number;
+        totalFOVs?: number;
     };
 }
 

--- a/src/state/selection/selectors.ts
+++ b/src/state/selection/selectors.ts
@@ -182,9 +182,10 @@ export const getCategoryGroupColorsAndNames = createSelector(
 
 // not truly a selector, it just seemed cleaner to make this one function instead of 3
 // (2 for each axis and one for the color by)
+// tooltip won't render if sent an empty string
 export function getFeatureDefTooltip(key: string, options: MeasuredFeatureDef[]): string {
     const data = find(options, { key: key });
-    if (data) {
+    if (data && data.tooltip) {
         return data.tooltip;
     }
     return "";


### PR DESCRIPTION
Problem
=======
we want to make sure the schema is consistent with what is truly required to not break the front end. Related to https://github.com/allen-cell-animated/cell-feature-data/issues/92

Solution
========
Most of these fields were already being treated as non required, but needed to make sure the interface is consistent 

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)
