### PR TITLE
refactor: Upgrade website-3d-cell-viewer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,6 @@ jobs:
               with:
                   node-version: 20
             - run: npm ci
-            - run: npm test --if-present
             - run: npm run lint --if-present
             - run: npm run typeCheck --if-present
+            - run: npm test --if-present

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
             - name: Use Node.js
               uses: actions/setup-node@v3
               with:
-                  node-version: 16
+                  node-version: 20
             - run: npm ci
             - run: npm test --if-present
             - run: npm run lint --if-present

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "ISC",
             "dependencies": {
                 "@aics/browsing-context-messaging": "~1.1",
-                "@aics/web-3d-viewer": "^2.7.4",
+                "@aics/web-3d-viewer": "^2.9.0",
                 "@ant-design/icons": "^4.2.2",
                 "antd": "^3.26.20",
                 "axios": "^0.21.1",
@@ -93,6 +93,94 @@
                 "webpack-dev-server": "^4.7.3"
             }
         },
+        "../website-3d-cell-viewer": {
+            "name": "@aics/web-3d-viewer",
+            "version": "2.9.0",
+            "license": "ISC",
+            "dependencies": {
+                "@aics/volume-viewer": "^3.9.0",
+                "@ant-design/icons": "^5.2.5",
+                "@fortawesome/fontawesome-svg-core": "^6.5.2",
+                "@fortawesome/free-solid-svg-icons": "^6.5.2",
+                "@fortawesome/react-fontawesome": "^0.2.0",
+                "color-string": "^1.5.3",
+                "d3": "^4.11.0",
+                "fuse.js": "^7.0.0",
+                "lodash": "^4.17.20",
+                "nouislider-react": "^3.4.0",
+                "react-color": "^2.19.3",
+                "react-router-dom": "^6.22.3",
+                "styled-components": "^6.1.8",
+                "usehooks-ts": "^3.1.0"
+            },
+            "devDependencies": {
+                "@babel/cli": "^7.14.5",
+                "@babel/core": "^7.14.6",
+                "@babel/preset-env": "^7.23.3",
+                "@babel/preset-react": "^7.14.5",
+                "@babel/preset-typescript": "^7.14.5",
+                "@babel/runtime": "^7.14.6",
+                "@dr.pogodin/babel-preset-svgr": "^1.8.0",
+                "@types/color-string": "^1.5.2",
+                "@types/d3": "^4.13.12",
+                "@types/jest": "^27.4.0",
+                "@types/lodash": "^4.14.185",
+                "@types/react": "^16.x",
+                "@types/react-color": "^3.0.6",
+                "@types/react-dom": "^16.x",
+                "@typescript-eslint/eslint-plugin": "^5.31.0",
+                "@typescript-eslint/parser": "^5.31.0",
+                "antd": "^5.16.2",
+                "axios": "^0.21.1",
+                "babel-loader": "^8.2.2",
+                "babel-plugin-replace-import-extension": "^1.1.3",
+                "clean-webpack-plugin": "^4.0.0-alpha.0",
+                "command-line-args": "^5.1.1",
+                "copy-webpack-plugin": "^11.0.0",
+                "cross-env": "^7.0.3",
+                "css-loader": "^6.2.0",
+                "esbuild": "^0.14.50",
+                "esbuild-jest": "^0.5.0",
+                "eslint": "^8.20.0",
+                "eslint-plugin-react": "^7.30.1",
+                "file-loader": "^6.2.0",
+                "firebase": "^7.15.3",
+                "gh-pages": "^4.0.0",
+                "html-webpack-plugin": "^5.3.2",
+                "jest": "^27.0.6",
+                "mini-css-extract-plugin": "^2.2.0",
+                "morgan": "^1.9.1",
+                "npm-run-all": "^4.1.5",
+                "postcss": "^8.4.31",
+                "postcss-cli": "^8.3.1",
+                "postcss-discard-comments": "^5.0.1",
+                "postcss-extend-rule": "^3.0.0",
+                "postcss-import": "^14.0.2",
+                "postcss-loader": "^6.1.1",
+                "postcss-mixins": "^8.1.0",
+                "postcss-nested": "^5.0.6",
+                "postcss-simple-vars": "^6.0.3",
+                "postcss-url": "^10.1.3",
+                "prop-types": "^15.5.10",
+                "react": "^16.12.0",
+                "react-dom": "^16.12.0",
+                "resolve-url-loader": "^5.0.0",
+                "style-loader": "^3.2.1",
+                "ts-jest": "^27.1.2",
+                "typescript": "^4.3.5",
+                "url-loader": "^4.1.1",
+                "webpack": "^5.89.0",
+                "webpack-cli": "^4.7.2",
+                "webpack-dev-server": "^4.9.3",
+                "webpack-merge": "^5.8.0",
+                "webpack-shell-plugin": "^0.5.0"
+            },
+            "peerDependencies": {
+                "antd": "^5.16.2",
+                "react": "16.x",
+                "react-dom": "16.x"
+            }
+        },
         "node_modules/@aashutoshrathi/word-wrap": {
             "version": "1.2.6",
             "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
@@ -107,34 +195,9 @@
             "resolved": "https://registry.npmjs.org/@aics/browsing-context-messaging/-/browsing-context-messaging-1.1.0.tgz",
             "integrity": "sha512-ts+Z8g/xTJaD+g9fAElEJbclk1L0xDsHy6ioq9N5T4j5WPew46WvZ/794Vxnn9N06KyjkCO6zc4JEl7ZZRSa5Q=="
         },
-        "node_modules/@aics/volume-viewer": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/@aics/volume-viewer/-/volume-viewer-3.5.3.tgz",
-            "integrity": "sha512-MmYW34eRZN9OHTSEWlNRBE1XZB5ddtEc1ueJEStaKPASJ8DO4O3bicsCLMIZeC5M0BxleK+pINzZfjgRuePKXQ==",
-            "dependencies": {
-                "geotiff": "^2.0.5",
-                "three": "^0.144.0",
-                "tweakpane": "^3.1.9",
-                "zarrita": "^0.3.2"
-            }
-        },
         "node_modules/@aics/web-3d-viewer": {
-            "version": "2.7.4",
-            "resolved": "https://registry.npmjs.org/@aics/web-3d-viewer/-/web-3d-viewer-2.7.4.tgz",
-            "integrity": "sha512-eFlLiPamCTQ9vxZSfMLGp+bwZCW+hmuRZ1/i9K4DTpMjjmmwjgyMsVG527SWRaLLKXWy7vRZk2GrW4jF0DJq2w==",
-            "dependencies": {
-                "@aics/volume-viewer": "^3.5.3",
-                "color-string": "^1.5.3",
-                "d3": "^4.11.0",
-                "lodash": "^4.17.20",
-                "nouislider-react": "^3.4.0",
-                "react-color": "^2.19.3"
-            },
-            "peerDependencies": {
-                "antd": "^3.26.20",
-                "react": "16.x",
-                "react-dom": "16.x"
-            }
+            "resolved": "../website-3d-cell-viewer",
+            "link": true
         },
         "node_modules/@ampproject/remapping": {
             "version": "2.2.1",
@@ -2584,14 +2647,6 @@
             "integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
             "dev": true
         },
-        "node_modules/@icons/material": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
-            "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==",
-            "peerDependencies": {
-                "react": "*"
-            }
-        },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.3.3",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
@@ -2762,11 +2817,6 @@
             "engines": {
                 "node": ">= 8"
             }
-        },
-        "node_modules/@petamoriken/float16": {
-            "version": "3.8.4",
-            "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.8.4.tgz",
-            "integrity": "sha512-kB+NJ5Br56ZhElKsf0pM7/PQfrDdDVMRz8f0JM6eVOGE+L89z9hwcst9QvWBBnazzuqGTGtPsJNZoQ1JdNiGSQ=="
         },
         "node_modules/@plotly/d3-sankey": {
             "version": "0.7.2",
@@ -3912,40 +3962,6 @@
             "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
             "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
             "dev": true
-        },
-        "node_modules/@zarrita/core": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/@zarrita/core/-/core-0.0.3.tgz",
-            "integrity": "sha512-fWv51b+xbYnws1pkNDPwJQoDa76aojxplHyMup82u11UAiet3gURMsrrkhM6YbeTgSY1A8oGxDOrvar3SiZpLA==",
-            "dependencies": {
-                "@zarrita/storage": "^0.0.2",
-                "@zarrita/typedarray": "^0.0.1",
-                "numcodecs": "^0.2.2"
-            }
-        },
-        "node_modules/@zarrita/indexing": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/@zarrita/indexing/-/indexing-0.0.3.tgz",
-            "integrity": "sha512-Q61d9MYX6dsK1DLltEpwx4mJWCZHj0TXiaEN4QpxNDtToa/EoyytP/pYHPypO4GXBscZooJ6eZkKT5FMx9PVfg==",
-            "dependencies": {
-                "@zarrita/core": "^0.0.3",
-                "@zarrita/storage": "^0.0.2",
-                "@zarrita/typedarray": "^0.0.1"
-            }
-        },
-        "node_modules/@zarrita/storage": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/@zarrita/storage/-/storage-0.0.2.tgz",
-            "integrity": "sha512-uFt4abAoiOYLroalNDAnVaQxA17zGKrQ0waYKmTVm+bNonz8ggKZP+0FqMhgUZITGChqoANHuYTazbuU5AFXWA==",
-            "dependencies": {
-                "reference-spec-reader": "^0.2.0",
-                "unzipit": "^1.3.6"
-            }
-        },
-        "node_modules/@zarrita/typedarray": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/@zarrita/typedarray/-/typedarray-0.0.1.tgz",
-            "integrity": "sha512-ZdvNjYP1bEuQXoSTVkemV99w42jHYrJ3nh9golCLd4MVBlrVbfZo4wWgBslU4JZUaDikhFSH+GWMDgAq/rI32g=="
         },
         "node_modules/3d-view": {
             "version": "2.0.1",
@@ -5416,15 +5432,6 @@
                 "mumath": "^3.3.4"
             }
         },
-        "node_modules/color-string": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-            "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-            "dependencies": {
-                "color-name": "^1.0.0",
-                "simple-swizzle": "^0.2.2"
-            }
-        },
         "node_modules/colorette": {
             "version": "2.0.20",
             "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
@@ -6099,73 +6106,10 @@
                 "type": "^1.0.1"
             }
         },
-        "node_modules/d3": {
-            "version": "4.13.0",
-            "resolved": "https://registry.npmjs.org/d3/-/d3-4.13.0.tgz",
-            "integrity": "sha512-l8c4+0SldjVKLaE2WG++EQlqD7mh/dmQjvi2L2lKPadAVC+TbJC4ci7Uk9bRi+To0+ansgsS0iWfPjD7DBy+FQ==",
-            "dependencies": {
-                "d3-array": "1.2.1",
-                "d3-axis": "1.0.8",
-                "d3-brush": "1.0.4",
-                "d3-chord": "1.0.4",
-                "d3-collection": "1.0.4",
-                "d3-color": "1.0.3",
-                "d3-dispatch": "1.0.3",
-                "d3-drag": "1.2.1",
-                "d3-dsv": "1.0.8",
-                "d3-ease": "1.0.3",
-                "d3-force": "1.1.0",
-                "d3-format": "1.2.2",
-                "d3-geo": "1.9.1",
-                "d3-hierarchy": "1.1.5",
-                "d3-interpolate": "1.1.6",
-                "d3-path": "1.0.5",
-                "d3-polygon": "1.0.3",
-                "d3-quadtree": "1.0.3",
-                "d3-queue": "3.0.7",
-                "d3-random": "1.1.0",
-                "d3-request": "1.0.6",
-                "d3-scale": "1.0.7",
-                "d3-selection": "1.3.0",
-                "d3-shape": "1.2.0",
-                "d3-time": "1.0.8",
-                "d3-time-format": "2.1.1",
-                "d3-timer": "1.0.7",
-                "d3-transition": "1.1.1",
-                "d3-voronoi": "1.1.2",
-                "d3-zoom": "1.7.1"
-            }
-        },
         "node_modules/d3-array": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.1.tgz",
             "integrity": "sha512-CyINJQ0SOUHojDdFDH4JEM0552vCR1utGyLHegJHyYH0JyCpSeTPxi4OBqHMA2jJZq4NH782LtaJWBImqI/HBw=="
-        },
-        "node_modules/d3-axis": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-1.0.8.tgz",
-            "integrity": "sha512-K0djTb26iQ6AsuD2d6Ka08wBHf4V30awIxV4XFuB/iLzYtTqqJlE/nIN0DBJJCX7lbOqbt2/oeX3r+sU5k2veg=="
-        },
-        "node_modules/d3-brush": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-1.0.4.tgz",
-            "integrity": "sha512-nUFueDzOlvwFvuOBynGSyJM7Wt1H9fKgJeoWFSg3ScS4c7FJBch92FKUJKum4xtgPYHdgH2C3bRg3GzSVltCJQ==",
-            "dependencies": {
-                "d3-dispatch": "1",
-                "d3-drag": "1",
-                "d3-interpolate": "1",
-                "d3-selection": "1",
-                "d3-transition": "1"
-            }
-        },
-        "node_modules/d3-chord": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-1.0.4.tgz",
-            "integrity": "sha512-o0ExexkK1N0KikUakKrQwttP5Flu8AYD6iBUh3AdPJqnTh6xlvcX5wFRuuo29sLOAr9+T4yZPUH1S3CCQJ1SlQ==",
-            "dependencies": {
-                "d3-array": "1",
-                "d3-path": "1"
-            }
         },
         "node_modules/d3-collection": {
             "version": "1.0.4",
@@ -6182,132 +6126,15 @@
             "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.3.tgz",
             "integrity": "sha512-Qh2DR3neW3lq/ug4oymXHYoIsA91nYt47ERb+fPKjRg6zLij06aP7KqHHl2NyziK9ASxrR3GLkHCtZvXe/jMVg=="
         },
-        "node_modules/d3-drag": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-1.2.1.tgz",
-            "integrity": "sha512-Cg8/K2rTtzxzrb0fmnYOUeZHvwa4PHzwXOLZZPwtEs2SKLLKLXeYwZKBB+DlOxUvFmarOnmt//cU4+3US2lyyQ==",
-            "dependencies": {
-                "d3-dispatch": "1",
-                "d3-selection": "1"
-            }
-        },
-        "node_modules/d3-dsv": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-1.0.8.tgz",
-            "integrity": "sha512-IVCJpQ+YGe3qu6odkPQI0KPqfxkhbP/oM1XhhE/DFiYmcXKfCRub4KXyiuehV1d4drjWVXHUWx4gHqhdZb6n/A==",
-            "dependencies": {
-                "commander": "2",
-                "iconv-lite": "0.4",
-                "rw": "1"
-            },
-            "bin": {
-                "csv2json": "bin/dsv2json",
-                "csv2tsv": "bin/dsv2dsv",
-                "dsv2dsv": "bin/dsv2dsv",
-                "dsv2json": "bin/dsv2json",
-                "json2csv": "bin/json2dsv",
-                "json2dsv": "bin/json2dsv",
-                "json2tsv": "bin/json2dsv",
-                "tsv2csv": "bin/dsv2dsv",
-                "tsv2json": "bin/dsv2json"
-            }
-        },
-        "node_modules/d3-ease": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.3.tgz",
-            "integrity": "sha512-io3QwOJwVPAxRF2UXpKpCdz2wm/7VLFCQQ1yy+GzX6YCtt3vi2BGnimI8agSF5jyUrHsADyF303d2S+ps7zU8w=="
-        },
-        "node_modules/d3-force": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.1.0.tgz",
-            "integrity": "sha512-2HVQz3/VCQs0QeRNZTYb7GxoUCeb6bOzMp/cGcLa87awY9ZsPvXOGeZm0iaGBjXic6I1ysKwMn+g+5jSAdzwcg==",
-            "dependencies": {
-                "d3-collection": "1",
-                "d3-dispatch": "1",
-                "d3-quadtree": "1",
-                "d3-timer": "1"
-            }
-        },
-        "node_modules/d3-format": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.2.2.tgz",
-            "integrity": "sha512-zH9CfF/3C8zUI47nsiKfD0+AGDEuM8LwBIP7pBVpyR4l/sKkZqITmMtxRp04rwBrlshIZ17XeFAaovN3++wzkw=="
-        },
-        "node_modules/d3-geo": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.9.1.tgz",
-            "integrity": "sha512-l9wL/cEQkyZQYXw3xbmLsH3eQ5ij+icNfo4r0GrLa5rOCZR/e/3am45IQ0FvQ5uMsv+77zBRunLc9ufTWSQYFA==",
-            "dependencies": {
-                "d3-array": "1"
-            }
-        },
-        "node_modules/d3-hierarchy": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-1.1.5.tgz",
-            "integrity": "sha512-PcsLIhThc60mWnxlojIOH7Sc0tQ2DgLWfEwEAyzCtej5f3H9wSsRmrg5pEhKZLrwiJnI2zyw/pznJxL9a/Eugw=="
-        },
-        "node_modules/d3-interpolate": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.1.6.tgz",
-            "integrity": "sha512-mOnv5a+pZzkNIHtw/V6I+w9Lqm9L5bG3OTXPM5A+QO0yyVMQ4W1uZhR+VOJmazaOZXri2ppbiZ5BUNWT0pFM9A==",
-            "dependencies": {
-                "d3-color": "1"
-            }
-        },
         "node_modules/d3-path": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.5.tgz",
             "integrity": "sha512-eD76prgnTKYkLzHlY2UMyOEZXTpC+WOanCr1BLxo38w4fPPPq/LgCFqRQvqFU3AJngfZmmKR7rgKPZ4EGJ9Atw=="
         },
-        "node_modules/d3-polygon": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-1.0.3.tgz",
-            "integrity": "sha512-2zP7GOvf4XOWTeQouK7fCO534yQxyhYYTw6GTqcXifIalHgA6qV/es+4GRQii9m6XxEPFcht4loobD/o2iEo1A=="
-        },
         "node_modules/d3-quadtree": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-1.0.3.tgz",
             "integrity": "sha512-U2Jc3jF3JOBGXIOnvWY9C4ekRwRX9hEVpMMmeduJyaxAwPmoe7t84iZFTLn1RwYOyrXxJF55H/Hrg186TFQQdw=="
-        },
-        "node_modules/d3-queue": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/d3-queue/-/d3-queue-3.0.7.tgz",
-            "integrity": "sha512-2rs+6pNFKkrJhqe1rg5znw7dKJ7KZr62j9aLZfhondkrnz6U7VRmJj1UGcbD8MRc46c7H8m4SWhab8EalBQrkw=="
-        },
-        "node_modules/d3-random": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-1.1.0.tgz",
-            "integrity": "sha512-XuMbjx3Jq4EWfJP4g6nR7zns/bZfaVbWHWfR8auDkEiWCzVbWifmasfszV1ZRN3xXK3nY4RUFL2nTIhceGZSFQ=="
-        },
-        "node_modules/d3-request": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/d3-request/-/d3-request-1.0.6.tgz",
-            "integrity": "sha512-FJj8ySY6GYuAJHZMaCQ83xEYE4KbkPkmxZ3Hu6zA1xxG2GD+z6P+Lyp+zjdsHf0xEbp2xcluDI50rCS855EQ6w==",
-            "dependencies": {
-                "d3-collection": "1",
-                "d3-dispatch": "1",
-                "d3-dsv": "1",
-                "xmlhttprequest": "1"
-            }
-        },
-        "node_modules/d3-scale": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
-            "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
-            "dependencies": {
-                "d3-array": "^1.2.0",
-                "d3-collection": "1",
-                "d3-color": "1",
-                "d3-format": "1",
-                "d3-interpolate": "1",
-                "d3-time": "1",
-                "d3-time-format": "2"
-            }
-        },
-        "node_modules/d3-selection": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.3.0.tgz",
-            "integrity": "sha512-qgpUOg9tl5CirdqESUAu0t9MU/t3O9klYfGfyKsXEmhyxyzLpzpeh08gaxBUTQw1uXIOkr/30Ut2YRjSSxlmHA=="
         },
         "node_modules/d3-shape": {
             "version": "1.2.0",
@@ -6322,48 +6149,10 @@
             "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.0.8.tgz",
             "integrity": "sha512-YRZkNhphZh3KcnBfitvF3c6E0JOFGikHZ4YqD+Lzv83ZHn1/u6yGenRU1m+KAk9J1GnZMnKcrtfvSktlA1DXNQ=="
         },
-        "node_modules/d3-time-format": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.1.1.tgz",
-            "integrity": "sha512-8kAkymq2WMfzW7e+s/IUNAtN/y3gZXGRrdGfo6R8NKPAA85UBTxZg5E61bR6nLwjPjj4d3zywSQe1CkYLPFyrw==",
-            "dependencies": {
-                "d3-time": "1"
-            }
-        },
         "node_modules/d3-timer": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.7.tgz",
             "integrity": "sha512-vMZXR88XujmG/L5oB96NNKH5lCWwiLM/S2HyyAQLcjWJCloK5shxta4CwOFYLZoY3AWX73v8Lgv4cCAdWtRmOA=="
-        },
-        "node_modules/d3-transition": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-1.1.1.tgz",
-            "integrity": "sha512-xeg8oggyQ+y5eb4J13iDgKIjUcEfIOZs2BqV/eEmXm2twx80wTzJ4tB4vaZ5BKfz7XsI/DFmQL5me6O27/5ykQ==",
-            "dependencies": {
-                "d3-color": "1",
-                "d3-dispatch": "1",
-                "d3-ease": "1",
-                "d3-interpolate": "1",
-                "d3-selection": "^1.1.0",
-                "d3-timer": "1"
-            }
-        },
-        "node_modules/d3-voronoi": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.2.tgz",
-            "integrity": "sha512-RhGS1u2vavcO7ay7ZNAPo4xeDh/VYeGof3x5ZLJBQgYhLegxr3s5IykvWmJ94FTU6mcbtp4sloqZ54mP6R4Utw=="
-        },
-        "node_modules/d3-zoom": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-1.7.1.tgz",
-            "integrity": "sha512-sZHQ55DGq5BZBFGnRshUT8tm2sfhPHFnOlmPbbwTkAoPeVdRTkB4Xsf9GCY0TSHrTD8PeJPZGmP/TpGicwJDJQ==",
-            "dependencies": {
-                "d3-dispatch": "1",
-                "d3-drag": "1",
-                "d3-interpolate": "1",
-                "d3-selection": "1",
-                "d3-transition": "1"
-            }
         },
         "node_modules/dashdash": {
             "version": "1.14.1",
@@ -8561,24 +8350,6 @@
             "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.1.tgz",
             "integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg=="
         },
-        "node_modules/geotiff": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.1.0.tgz",
-            "integrity": "sha512-B/iFJuFfRpmPHXf8aIRPRgUWwfaNb6dlsynkM8SWeHAPu7CpyvfqEa43KlBt7xxq5OTVysQacFHxhCn3SZhRKQ==",
-            "dependencies": {
-                "@petamoriken/float16": "^3.4.7",
-                "lerc": "^3.0.0",
-                "pako": "^2.0.4",
-                "parse-headers": "^2.0.2",
-                "quick-lru": "^6.1.1",
-                "web-worker": "^1.2.0",
-                "xml-utils": "^1.0.2",
-                "zstddec": "^0.1.0"
-            },
-            "engines": {
-                "node": ">=10.19"
-            }
-        },
         "node_modules/get-caller-file": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -9813,6 +9584,7 @@
             "version": "0.4.24",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
             "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "dev": true,
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3"
             },
@@ -10875,11 +10647,6 @@
             "deprecated": "use String.prototype.padStart()",
             "dev": true
         },
-        "node_modules/lerc": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
-            "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww=="
-        },
         "node_modules/lerp": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/lerp/-/lerp-1.0.3.tgz",
@@ -11047,7 +10814,8 @@
         "node_modules/lodash-es": {
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-            "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+            "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+            "dev": true
         },
         "node_modules/lodash.camelcase": {
             "version": "4.3.0",
@@ -11269,11 +11037,6 @@
             "dependencies": {
                 "gl-mat4": "^1.0.1"
             }
-        },
-        "node_modules/material-colors": {
-            "version": "1.2.6",
-            "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
-            "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
         },
         "node_modules/math-log2": {
             "version": "1.0.1",
@@ -12003,23 +11766,6 @@
             "resolved": "https://registry.npmjs.org/normals/-/normals-1.1.0.tgz",
             "integrity": "sha512-XWeliW48BLvbVJ+cjQAOE+tA0m1M7Yi1iTPphAS9tBmW1A/c/cOVnEUecPCCMH5lEAihAcG6IRle56ls9k3xug=="
         },
-        "node_modules/nouislider": {
-            "version": "14.7.0",
-            "resolved": "https://registry.npmjs.org/nouislider/-/nouislider-14.7.0.tgz",
-            "integrity": "sha512-4RtQ1+LHJKesDCNJrXkQcwXAWCrC2aggdLYMstS/G5fEWL+fXZbUA9pwVNHFghMGuFGRATlDLNInRaPeRKzpFQ=="
-        },
-        "node_modules/nouislider-react": {
-            "version": "3.4.1",
-            "resolved": "https://registry.npmjs.org/nouislider-react/-/nouislider-react-3.4.1.tgz",
-            "integrity": "sha512-ryVbcApz6sELqPPiWwEOq5pkwhHYoNSxmGpP/HXHptpB6A6XedMrM/BP5W/rHRtBBaFK7vJTCTTma6gKviEiNg==",
-            "dependencies": {
-                "nouislider": "^14.6.3"
-            },
-            "peerDependencies": {
-                "nouislider": ">= 11.x",
-                "react": ">= 16.8.x"
-            }
-        },
         "node_modules/npm-run-path": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -12059,14 +11805,6 @@
             },
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/numcodecs": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/numcodecs/-/numcodecs-0.2.2.tgz",
-            "integrity": "sha512-Y5K8mv80yb4MgVpcElBkUeMZqeE4TrovxRit/dTZvoRl6YkB6WEjY+fiUjGCblITnt3T3fmrDg8yRWu0gOLjhQ==",
-            "engines": {
-                "node": ">=12"
             }
         },
         "node_modules/numeric": {
@@ -12391,11 +12129,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/pako": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
-            "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
-        },
         "node_modules/param-case": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
@@ -12428,11 +12161,6 @@
             "version": "3.1.8",
             "resolved": "https://registry.npmjs.org/parenthesis/-/parenthesis-3.1.8.tgz",
             "integrity": "sha512-KF/U8tk54BgQewkJPvB4s/US3VQY68BRDpH638+7O/n58TpnwiwnOtGIOsT2/i+M78s61BBpeC83STB88d8sqw=="
-        },
-        "node_modules/parse-headers": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.5.tgz",
-            "integrity": "sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA=="
         },
         "node_modules/parse-json": {
             "version": "5.2.0",
@@ -14513,17 +14241,6 @@
                 }
             ]
         },
-        "node_modules/quick-lru": {
-            "version": "6.1.2",
-            "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.2.tgz",
-            "integrity": "sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ==",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/quickselect": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
@@ -15369,23 +15086,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/react-color": {
-            "version": "2.19.3",
-            "resolved": "https://registry.npmjs.org/react-color/-/react-color-2.19.3.tgz",
-            "integrity": "sha512-LEeGE/ZzNLIsFWa1TMe8y5VYqr7bibneWmvJwm1pCn/eNmrabWDh659JSPn9BuaMpEfU83WTOJfnCcjDZwNQTA==",
-            "dependencies": {
-                "@icons/material": "^0.2.4",
-                "lodash": "^4.17.15",
-                "lodash-es": "^4.17.15",
-                "material-colors": "^1.2.1",
-                "prop-types": "^15.5.10",
-                "reactcss": "^1.2.0",
-                "tinycolor2": "^1.4.1"
-            },
-            "peerDependencies": {
-                "react": "*"
-            }
-        },
         "node_modules/react-dom": {
             "version": "16.14.0",
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
@@ -15471,14 +15171,6 @@
                 "react-dom": "^0.14.0 || ^15.0.1 || ^16.0.0"
             }
         },
-        "node_modules/reactcss": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
-            "integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
-            "dependencies": {
-                "lodash": "^4.0.1"
-            }
-        },
         "node_modules/readable-stream": {
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
@@ -15559,11 +15251,6 @@
             "peerDependencies": {
                 "redux": ">=3.5.2"
             }
-        },
-        "node_modules/reference-spec-reader": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/reference-spec-reader/-/reference-spec-reader-0.2.0.tgz",
-            "integrity": "sha512-q0mfCi5yZSSHXpCyxjgQeaORq3tvDsxDyzaadA/5+AbAUwRyRuuTh0aRQuE/vAOt/qzzxidJ5iDeu1cLHaNBlQ=="
         },
         "node_modules/reflect.getprototypeof": {
             "version": "1.0.4",
@@ -16628,19 +16315,6 @@
             "resolved": "https://registry.npmjs.org/signum/-/signum-1.0.0.tgz",
             "integrity": "sha512-yodFGwcyt59XRh7w5W3jPcIQb3Bwi21suEfT7MAWnBX3iCdklJpgDgvGT9o04UonglZN5SNMfJFkHIR/jO8GHw=="
         },
-        "node_modules/simple-swizzle": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-            "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
-            "dependencies": {
-                "is-arrayish": "^0.3.1"
-            }
-        },
-        "node_modules/simple-swizzle/node_modules/is-arrayish": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-            "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
-        },
         "node_modules/simplicial-complex": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/simplicial-complex/-/simplicial-complex-1.0.0.tgz",
@@ -17264,11 +16938,6 @@
             "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
             "dev": true
         },
-        "node_modules/three": {
-            "version": "0.144.0",
-            "resolved": "https://registry.npmjs.org/three/-/three-0.144.0.tgz",
-            "integrity": "sha512-R8AXPuqfjfRJKkYoTQcTK7A6i3AdO9++2n8ubya/GTU+fEHhYKu1ZooRSCPkx69jbnzT7dD/xEo6eROQTt2lJw=="
-        },
         "node_modules/through2": {
             "version": "0.6.5",
             "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
@@ -17694,14 +17363,6 @@
                 "gl-vec3": "^1.0.2"
             }
         },
-        "node_modules/tweakpane": {
-            "version": "3.1.10",
-            "resolved": "https://registry.npmjs.org/tweakpane/-/tweakpane-3.1.10.tgz",
-            "integrity": "sha512-rqwnl/pUa7+inhI2E9ayGTqqP0EPOOn/wVvSWjZsRbZUItzNShny7pzwL3hVlaN4m9t/aZhsP0aFQ9U5VVR2VQ==",
-            "funding": {
-                "url": "https://github.com/sponsors/cocopon"
-            }
-        },
         "node_modules/tweetnacl": {
             "version": "0.14.5",
             "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
@@ -17976,17 +17637,6 @@
             "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
             "integrity": "sha512-vRCqFv6UhXpWxZPyGDh/F3ZpNv8/qo7w6iufLpQg9aKnQ71qM4B5KiI7Mia9COcjEhrO9LueHpMYjYzsWH3OIg=="
         },
-        "node_modules/unzipit": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/unzipit/-/unzipit-1.4.3.tgz",
-            "integrity": "sha512-gsq2PdJIWWGhx5kcdWStvNWit9FVdTewm4SEG7gFskWs+XCVaULt9+BwuoBtJiRE8eo3L1IPAOrbByNLtLtIlg==",
-            "dependencies": {
-                "uzip-module": "^1.0.2"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
         "node_modules/update-browserslist-db": {
             "version": "1.0.13",
             "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
@@ -18106,11 +17756,6 @@
                 "uuid": "bin/uuid"
             }
         },
-        "node_modules/uzip-module": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/uzip-module/-/uzip-module-1.0.3.tgz",
-            "integrity": "sha512-AMqwWZaknLM77G+VPYNZLEruMGWGzyigPK3/Whg99B3S6vGHuqsyl5ZrOv1UUF3paGK1U6PM0cnayioaryg/fA=="
-        },
         "node_modules/v8-compile-cache-lib": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -18224,11 +17869,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/weakmap-shim/-/weakmap-shim-1.1.1.tgz",
             "integrity": "sha512-/wNyG+1FpiHhnfQo+TuA/XAUpvOOkKVl0A4qpT+oGcj5SlZCLmM+M1Py/3Sj8sy+YrEauCVITOxCsZKo6sPbQg=="
-        },
-        "node_modules/web-worker": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.2.0.tgz",
-            "integrity": "sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA=="
         },
         "node_modules/webgl-context": {
             "version": "2.2.0",
@@ -18930,11 +18570,6 @@
             "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
             "dev": true
         },
-        "node_modules/xml-utils": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.7.0.tgz",
-            "integrity": "sha512-bWB489+RQQclC7A9OW8e5BzbT8Tu//jtAOvkYwewFr+Q9T9KDGvfzC1lp0pYPEQPEoPQLDkmxkepSC/2gIAZGw=="
-        },
         "node_modules/xmlhttprequest": {
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
@@ -19020,16 +18655,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/zarrita": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/zarrita/-/zarrita-0.3.2.tgz",
-            "integrity": "sha512-Zx9nS28C2tXZhF1BmQkgQGi0M/Z5JiM/KCMa+fEYtr/MnIzyizR4sKRA/sXjDP1iuylILWTJAWWBJD//0ONXCA==",
-            "dependencies": {
-                "@zarrita/core": "^0.0.3",
-                "@zarrita/indexing": "^0.0.3",
-                "@zarrita/storage": "^0.0.2"
-            }
-        },
         "node_modules/zero-crossings": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/zero-crossings/-/zero-crossings-1.0.1.tgz",
@@ -19037,11 +18662,6 @@
             "dependencies": {
                 "cwise-compiler": "^1.0.0"
             }
-        },
-        "node_modules/zstddec": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.1.0.tgz",
-            "integrity": "sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg=="
         }
     },
     "dependencies": {
@@ -19056,28 +18676,83 @@
             "resolved": "https://registry.npmjs.org/@aics/browsing-context-messaging/-/browsing-context-messaging-1.1.0.tgz",
             "integrity": "sha512-ts+Z8g/xTJaD+g9fAElEJbclk1L0xDsHy6ioq9N5T4j5WPew46WvZ/794Vxnn9N06KyjkCO6zc4JEl7ZZRSa5Q=="
         },
-        "@aics/volume-viewer": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/@aics/volume-viewer/-/volume-viewer-3.5.3.tgz",
-            "integrity": "sha512-MmYW34eRZN9OHTSEWlNRBE1XZB5ddtEc1ueJEStaKPASJ8DO4O3bicsCLMIZeC5M0BxleK+pINzZfjgRuePKXQ==",
-            "requires": {
-                "geotiff": "^2.0.5",
-                "three": "^0.144.0",
-                "tweakpane": "^3.1.9",
-                "zarrita": "^0.3.2"
-            }
-        },
         "@aics/web-3d-viewer": {
-            "version": "2.7.4",
-            "resolved": "https://registry.npmjs.org/@aics/web-3d-viewer/-/web-3d-viewer-2.7.4.tgz",
-            "integrity": "sha512-eFlLiPamCTQ9vxZSfMLGp+bwZCW+hmuRZ1/i9K4DTpMjjmmwjgyMsVG527SWRaLLKXWy7vRZk2GrW4jF0DJq2w==",
+            "version": "file:../website-3d-cell-viewer",
             "requires": {
-                "@aics/volume-viewer": "^3.5.3",
+                "@aics/volume-viewer": "^3.9.0",
+                "@ant-design/icons": "^5.2.5",
+                "@babel/cli": "^7.14.5",
+                "@babel/core": "^7.14.6",
+                "@babel/preset-env": "^7.23.3",
+                "@babel/preset-react": "^7.14.5",
+                "@babel/preset-typescript": "^7.14.5",
+                "@babel/runtime": "^7.14.6",
+                "@dr.pogodin/babel-preset-svgr": "^1.8.0",
+                "@fortawesome/fontawesome-svg-core": "^6.5.2",
+                "@fortawesome/free-solid-svg-icons": "^6.5.2",
+                "@fortawesome/react-fontawesome": "^0.2.0",
+                "@types/color-string": "^1.5.2",
+                "@types/d3": "^4.13.12",
+                "@types/jest": "^27.4.0",
+                "@types/lodash": "^4.14.185",
+                "@types/react": "^16.x",
+                "@types/react-color": "^3.0.6",
+                "@types/react-dom": "^16.x",
+                "@typescript-eslint/eslint-plugin": "^5.31.0",
+                "@typescript-eslint/parser": "^5.31.0",
+                "antd": "^5.16.2",
+                "axios": "^0.21.1",
+                "babel-loader": "^8.2.2",
+                "babel-plugin-replace-import-extension": "^1.1.3",
+                "clean-webpack-plugin": "^4.0.0-alpha.0",
                 "color-string": "^1.5.3",
+                "command-line-args": "^5.1.1",
+                "copy-webpack-plugin": "^11.0.0",
+                "cross-env": "^7.0.3",
+                "css-loader": "^6.2.0",
                 "d3": "^4.11.0",
+                "esbuild": "^0.14.50",
+                "esbuild-jest": "^0.5.0",
+                "eslint": "^8.20.0",
+                "eslint-plugin-react": "^7.30.1",
+                "file-loader": "^6.2.0",
+                "firebase": "^7.15.3",
+                "fuse.js": "^7.0.0",
+                "gh-pages": "^4.0.0",
+                "html-webpack-plugin": "^5.3.2",
+                "jest": "^27.0.6",
                 "lodash": "^4.17.20",
+                "mini-css-extract-plugin": "^2.2.0",
+                "morgan": "^1.9.1",
                 "nouislider-react": "^3.4.0",
-                "react-color": "^2.19.3"
+                "npm-run-all": "^4.1.5",
+                "postcss": "^8.4.31",
+                "postcss-cli": "^8.3.1",
+                "postcss-discard-comments": "^5.0.1",
+                "postcss-extend-rule": "^3.0.0",
+                "postcss-import": "^14.0.2",
+                "postcss-loader": "^6.1.1",
+                "postcss-mixins": "^8.1.0",
+                "postcss-nested": "^5.0.6",
+                "postcss-simple-vars": "^6.0.3",
+                "postcss-url": "^10.1.3",
+                "prop-types": "^15.5.10",
+                "react": "^16.12.0",
+                "react-color": "^2.19.3",
+                "react-dom": "^16.12.0",
+                "react-router-dom": "^6.22.3",
+                "resolve-url-loader": "^5.0.0",
+                "style-loader": "^3.2.1",
+                "styled-components": "^6.1.8",
+                "ts-jest": "^27.1.2",
+                "typescript": "^4.3.5",
+                "url-loader": "^4.1.1",
+                "usehooks-ts": "^3.1.0",
+                "webpack": "^5.89.0",
+                "webpack-cli": "^4.7.2",
+                "webpack-dev-server": "^4.9.3",
+                "webpack-merge": "^5.8.0",
+                "webpack-shell-plugin": "^0.5.0"
             }
         },
         "@ampproject/remapping": {
@@ -20815,12 +20490,6 @@
             "integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
             "dev": true
         },
-        "@icons/material": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
-            "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==",
-            "requires": {}
-        },
         "@jridgewell/gen-mapping": {
             "version": "0.3.3",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
@@ -20961,11 +20630,6 @@
                 "@nodelib/fs.scandir": "2.1.5",
                 "fastq": "^1.6.0"
             }
-        },
-        "@petamoriken/float16": {
-            "version": "3.8.4",
-            "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.8.4.tgz",
-            "integrity": "sha512-kB+NJ5Br56ZhElKsf0pM7/PQfrDdDVMRz8f0JM6eVOGE+L89z9hwcst9QvWBBnazzuqGTGtPsJNZoQ1JdNiGSQ=="
         },
         "@plotly/d3-sankey": {
             "version": "0.7.2",
@@ -21968,40 +21632,6 @@
             "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
             "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
             "dev": true
-        },
-        "@zarrita/core": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/@zarrita/core/-/core-0.0.3.tgz",
-            "integrity": "sha512-fWv51b+xbYnws1pkNDPwJQoDa76aojxplHyMup82u11UAiet3gURMsrrkhM6YbeTgSY1A8oGxDOrvar3SiZpLA==",
-            "requires": {
-                "@zarrita/storage": "^0.0.2",
-                "@zarrita/typedarray": "^0.0.1",
-                "numcodecs": "^0.2.2"
-            }
-        },
-        "@zarrita/indexing": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/@zarrita/indexing/-/indexing-0.0.3.tgz",
-            "integrity": "sha512-Q61d9MYX6dsK1DLltEpwx4mJWCZHj0TXiaEN4QpxNDtToa/EoyytP/pYHPypO4GXBscZooJ6eZkKT5FMx9PVfg==",
-            "requires": {
-                "@zarrita/core": "^0.0.3",
-                "@zarrita/storage": "^0.0.2",
-                "@zarrita/typedarray": "^0.0.1"
-            }
-        },
-        "@zarrita/storage": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/@zarrita/storage/-/storage-0.0.2.tgz",
-            "integrity": "sha512-uFt4abAoiOYLroalNDAnVaQxA17zGKrQ0waYKmTVm+bNonz8ggKZP+0FqMhgUZITGChqoANHuYTazbuU5AFXWA==",
-            "requires": {
-                "reference-spec-reader": "^0.2.0",
-                "unzipit": "^1.3.6"
-            }
-        },
-        "@zarrita/typedarray": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/@zarrita/typedarray/-/typedarray-0.0.1.tgz",
-            "integrity": "sha512-ZdvNjYP1bEuQXoSTVkemV99w42jHYrJ3nh9golCLd4MVBlrVbfZo4wWgBslU4JZUaDikhFSH+GWMDgAq/rI32g=="
         },
         "3d-view": {
             "version": "2.0.1",
@@ -23203,15 +22833,6 @@
                 "mumath": "^3.3.4"
             }
         },
-        "color-string": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-            "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-            "requires": {
-                "color-name": "^1.0.0",
-                "simple-swizzle": "^0.2.2"
-            }
-        },
         "colorette": {
             "version": "2.0.20",
             "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
@@ -23768,73 +23389,10 @@
                 "type": "^1.0.1"
             }
         },
-        "d3": {
-            "version": "4.13.0",
-            "resolved": "https://registry.npmjs.org/d3/-/d3-4.13.0.tgz",
-            "integrity": "sha512-l8c4+0SldjVKLaE2WG++EQlqD7mh/dmQjvi2L2lKPadAVC+TbJC4ci7Uk9bRi+To0+ansgsS0iWfPjD7DBy+FQ==",
-            "requires": {
-                "d3-array": "1.2.1",
-                "d3-axis": "1.0.8",
-                "d3-brush": "1.0.4",
-                "d3-chord": "1.0.4",
-                "d3-collection": "1.0.4",
-                "d3-color": "1.0.3",
-                "d3-dispatch": "1.0.3",
-                "d3-drag": "1.2.1",
-                "d3-dsv": "1.0.8",
-                "d3-ease": "1.0.3",
-                "d3-force": "1.1.0",
-                "d3-format": "1.2.2",
-                "d3-geo": "1.9.1",
-                "d3-hierarchy": "1.1.5",
-                "d3-interpolate": "1.1.6",
-                "d3-path": "1.0.5",
-                "d3-polygon": "1.0.3",
-                "d3-quadtree": "1.0.3",
-                "d3-queue": "3.0.7",
-                "d3-random": "1.1.0",
-                "d3-request": "1.0.6",
-                "d3-scale": "1.0.7",
-                "d3-selection": "1.3.0",
-                "d3-shape": "1.2.0",
-                "d3-time": "1.0.8",
-                "d3-time-format": "2.1.1",
-                "d3-timer": "1.0.7",
-                "d3-transition": "1.1.1",
-                "d3-voronoi": "1.1.2",
-                "d3-zoom": "1.7.1"
-            }
-        },
         "d3-array": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.1.tgz",
             "integrity": "sha512-CyINJQ0SOUHojDdFDH4JEM0552vCR1utGyLHegJHyYH0JyCpSeTPxi4OBqHMA2jJZq4NH782LtaJWBImqI/HBw=="
-        },
-        "d3-axis": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-1.0.8.tgz",
-            "integrity": "sha512-K0djTb26iQ6AsuD2d6Ka08wBHf4V30awIxV4XFuB/iLzYtTqqJlE/nIN0DBJJCX7lbOqbt2/oeX3r+sU5k2veg=="
-        },
-        "d3-brush": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-1.0.4.tgz",
-            "integrity": "sha512-nUFueDzOlvwFvuOBynGSyJM7Wt1H9fKgJeoWFSg3ScS4c7FJBch92FKUJKum4xtgPYHdgH2C3bRg3GzSVltCJQ==",
-            "requires": {
-                "d3-dispatch": "1",
-                "d3-drag": "1",
-                "d3-interpolate": "1",
-                "d3-selection": "1",
-                "d3-transition": "1"
-            }
-        },
-        "d3-chord": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-1.0.4.tgz",
-            "integrity": "sha512-o0ExexkK1N0KikUakKrQwttP5Flu8AYD6iBUh3AdPJqnTh6xlvcX5wFRuuo29sLOAr9+T4yZPUH1S3CCQJ1SlQ==",
-            "requires": {
-                "d3-array": "1",
-                "d3-path": "1"
-            }
         },
         "d3-collection": {
             "version": "1.0.4",
@@ -23851,121 +23409,15 @@
             "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.3.tgz",
             "integrity": "sha512-Qh2DR3neW3lq/ug4oymXHYoIsA91nYt47ERb+fPKjRg6zLij06aP7KqHHl2NyziK9ASxrR3GLkHCtZvXe/jMVg=="
         },
-        "d3-drag": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-1.2.1.tgz",
-            "integrity": "sha512-Cg8/K2rTtzxzrb0fmnYOUeZHvwa4PHzwXOLZZPwtEs2SKLLKLXeYwZKBB+DlOxUvFmarOnmt//cU4+3US2lyyQ==",
-            "requires": {
-                "d3-dispatch": "1",
-                "d3-selection": "1"
-            }
-        },
-        "d3-dsv": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-1.0.8.tgz",
-            "integrity": "sha512-IVCJpQ+YGe3qu6odkPQI0KPqfxkhbP/oM1XhhE/DFiYmcXKfCRub4KXyiuehV1d4drjWVXHUWx4gHqhdZb6n/A==",
-            "requires": {
-                "commander": "2",
-                "iconv-lite": "0.4",
-                "rw": "1"
-            }
-        },
-        "d3-ease": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.3.tgz",
-            "integrity": "sha512-io3QwOJwVPAxRF2UXpKpCdz2wm/7VLFCQQ1yy+GzX6YCtt3vi2BGnimI8agSF5jyUrHsADyF303d2S+ps7zU8w=="
-        },
-        "d3-force": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.1.0.tgz",
-            "integrity": "sha512-2HVQz3/VCQs0QeRNZTYb7GxoUCeb6bOzMp/cGcLa87awY9ZsPvXOGeZm0iaGBjXic6I1ysKwMn+g+5jSAdzwcg==",
-            "requires": {
-                "d3-collection": "1",
-                "d3-dispatch": "1",
-                "d3-quadtree": "1",
-                "d3-timer": "1"
-            }
-        },
-        "d3-format": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.2.2.tgz",
-            "integrity": "sha512-zH9CfF/3C8zUI47nsiKfD0+AGDEuM8LwBIP7pBVpyR4l/sKkZqITmMtxRp04rwBrlshIZ17XeFAaovN3++wzkw=="
-        },
-        "d3-geo": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.9.1.tgz",
-            "integrity": "sha512-l9wL/cEQkyZQYXw3xbmLsH3eQ5ij+icNfo4r0GrLa5rOCZR/e/3am45IQ0FvQ5uMsv+77zBRunLc9ufTWSQYFA==",
-            "requires": {
-                "d3-array": "1"
-            }
-        },
-        "d3-hierarchy": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-1.1.5.tgz",
-            "integrity": "sha512-PcsLIhThc60mWnxlojIOH7Sc0tQ2DgLWfEwEAyzCtej5f3H9wSsRmrg5pEhKZLrwiJnI2zyw/pznJxL9a/Eugw=="
-        },
-        "d3-interpolate": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.1.6.tgz",
-            "integrity": "sha512-mOnv5a+pZzkNIHtw/V6I+w9Lqm9L5bG3OTXPM5A+QO0yyVMQ4W1uZhR+VOJmazaOZXri2ppbiZ5BUNWT0pFM9A==",
-            "requires": {
-                "d3-color": "1"
-            }
-        },
         "d3-path": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.5.tgz",
             "integrity": "sha512-eD76prgnTKYkLzHlY2UMyOEZXTpC+WOanCr1BLxo38w4fPPPq/LgCFqRQvqFU3AJngfZmmKR7rgKPZ4EGJ9Atw=="
         },
-        "d3-polygon": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-1.0.3.tgz",
-            "integrity": "sha512-2zP7GOvf4XOWTeQouK7fCO534yQxyhYYTw6GTqcXifIalHgA6qV/es+4GRQii9m6XxEPFcht4loobD/o2iEo1A=="
-        },
         "d3-quadtree": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-1.0.3.tgz",
             "integrity": "sha512-U2Jc3jF3JOBGXIOnvWY9C4ekRwRX9hEVpMMmeduJyaxAwPmoe7t84iZFTLn1RwYOyrXxJF55H/Hrg186TFQQdw=="
-        },
-        "d3-queue": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/d3-queue/-/d3-queue-3.0.7.tgz",
-            "integrity": "sha512-2rs+6pNFKkrJhqe1rg5znw7dKJ7KZr62j9aLZfhondkrnz6U7VRmJj1UGcbD8MRc46c7H8m4SWhab8EalBQrkw=="
-        },
-        "d3-random": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-1.1.0.tgz",
-            "integrity": "sha512-XuMbjx3Jq4EWfJP4g6nR7zns/bZfaVbWHWfR8auDkEiWCzVbWifmasfszV1ZRN3xXK3nY4RUFL2nTIhceGZSFQ=="
-        },
-        "d3-request": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/d3-request/-/d3-request-1.0.6.tgz",
-            "integrity": "sha512-FJj8ySY6GYuAJHZMaCQ83xEYE4KbkPkmxZ3Hu6zA1xxG2GD+z6P+Lyp+zjdsHf0xEbp2xcluDI50rCS855EQ6w==",
-            "requires": {
-                "d3-collection": "1",
-                "d3-dispatch": "1",
-                "d3-dsv": "1",
-                "xmlhttprequest": "1"
-            }
-        },
-        "d3-scale": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
-            "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
-            "requires": {
-                "d3-array": "^1.2.0",
-                "d3-collection": "1",
-                "d3-color": "1",
-                "d3-format": "1",
-                "d3-interpolate": "1",
-                "d3-time": "1",
-                "d3-time-format": "2"
-            }
-        },
-        "d3-selection": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.3.0.tgz",
-            "integrity": "sha512-qgpUOg9tl5CirdqESUAu0t9MU/t3O9klYfGfyKsXEmhyxyzLpzpeh08gaxBUTQw1uXIOkr/30Ut2YRjSSxlmHA=="
         },
         "d3-shape": {
             "version": "1.2.0",
@@ -23980,48 +23432,10 @@
             "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.0.8.tgz",
             "integrity": "sha512-YRZkNhphZh3KcnBfitvF3c6E0JOFGikHZ4YqD+Lzv83ZHn1/u6yGenRU1m+KAk9J1GnZMnKcrtfvSktlA1DXNQ=="
         },
-        "d3-time-format": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.1.1.tgz",
-            "integrity": "sha512-8kAkymq2WMfzW7e+s/IUNAtN/y3gZXGRrdGfo6R8NKPAA85UBTxZg5E61bR6nLwjPjj4d3zywSQe1CkYLPFyrw==",
-            "requires": {
-                "d3-time": "1"
-            }
-        },
         "d3-timer": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.7.tgz",
             "integrity": "sha512-vMZXR88XujmG/L5oB96NNKH5lCWwiLM/S2HyyAQLcjWJCloK5shxta4CwOFYLZoY3AWX73v8Lgv4cCAdWtRmOA=="
-        },
-        "d3-transition": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-1.1.1.tgz",
-            "integrity": "sha512-xeg8oggyQ+y5eb4J13iDgKIjUcEfIOZs2BqV/eEmXm2twx80wTzJ4tB4vaZ5BKfz7XsI/DFmQL5me6O27/5ykQ==",
-            "requires": {
-                "d3-color": "1",
-                "d3-dispatch": "1",
-                "d3-ease": "1",
-                "d3-interpolate": "1",
-                "d3-selection": "^1.1.0",
-                "d3-timer": "1"
-            }
-        },
-        "d3-voronoi": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.2.tgz",
-            "integrity": "sha512-RhGS1u2vavcO7ay7ZNAPo4xeDh/VYeGof3x5ZLJBQgYhLegxr3s5IykvWmJ94FTU6mcbtp4sloqZ54mP6R4Utw=="
-        },
-        "d3-zoom": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-1.7.1.tgz",
-            "integrity": "sha512-sZHQ55DGq5BZBFGnRshUT8tm2sfhPHFnOlmPbbwTkAoPeVdRTkB4Xsf9GCY0TSHrTD8PeJPZGmP/TpGicwJDJQ==",
-            "requires": {
-                "d3-dispatch": "1",
-                "d3-drag": "1",
-                "d3-interpolate": "1",
-                "d3-selection": "1",
-                "d3-transition": "1"
-            }
         },
         "dashdash": {
             "version": "1.14.1",
@@ -25756,21 +25170,6 @@
             "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.1.tgz",
             "integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg=="
         },
-        "geotiff": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.1.0.tgz",
-            "integrity": "sha512-B/iFJuFfRpmPHXf8aIRPRgUWwfaNb6dlsynkM8SWeHAPu7CpyvfqEa43KlBt7xxq5OTVysQacFHxhCn3SZhRKQ==",
-            "requires": {
-                "@petamoriken/float16": "^3.4.7",
-                "lerc": "^3.0.0",
-                "pako": "^2.0.4",
-                "parse-headers": "^2.0.2",
-                "quick-lru": "^6.1.1",
-                "web-worker": "^1.2.0",
-                "xml-utils": "^1.0.2",
-                "zstddec": "^0.1.0"
-            }
-        },
         "get-caller-file": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -26833,6 +26232,7 @@
             "version": "0.4.24",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
             "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "dev": true,
             "requires": {
                 "safer-buffer": ">= 2.1.2 < 3"
             }
@@ -27624,11 +27024,6 @@
             "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
             "dev": true
         },
-        "lerc": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
-            "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww=="
-        },
         "lerp": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/lerp/-/lerp-1.0.3.tgz",
@@ -27754,7 +27149,8 @@
         "lodash-es": {
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-            "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+            "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+            "dev": true
         },
         "lodash.camelcase": {
             "version": "4.3.0",
@@ -27967,11 +27363,6 @@
             "requires": {
                 "gl-mat4": "^1.0.1"
             }
-        },
-        "material-colors": {
-            "version": "1.2.6",
-            "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
-            "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
         },
         "math-log2": {
             "version": "1.0.1",
@@ -28574,19 +27965,6 @@
             "resolved": "https://registry.npmjs.org/normals/-/normals-1.1.0.tgz",
             "integrity": "sha512-XWeliW48BLvbVJ+cjQAOE+tA0m1M7Yi1iTPphAS9tBmW1A/c/cOVnEUecPCCMH5lEAihAcG6IRle56ls9k3xug=="
         },
-        "nouislider": {
-            "version": "14.7.0",
-            "resolved": "https://registry.npmjs.org/nouislider/-/nouislider-14.7.0.tgz",
-            "integrity": "sha512-4RtQ1+LHJKesDCNJrXkQcwXAWCrC2aggdLYMstS/G5fEWL+fXZbUA9pwVNHFghMGuFGRATlDLNInRaPeRKzpFQ=="
-        },
-        "nouislider-react": {
-            "version": "3.4.1",
-            "resolved": "https://registry.npmjs.org/nouislider-react/-/nouislider-react-3.4.1.tgz",
-            "integrity": "sha512-ryVbcApz6sELqPPiWwEOq5pkwhHYoNSxmGpP/HXHptpB6A6XedMrM/BP5W/rHRtBBaFK7vJTCTTma6gKviEiNg==",
-            "requires": {
-                "nouislider": "^14.6.3"
-            }
-        },
         "npm-run-path": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -28618,11 +27996,6 @@
             "requires": {
                 "is-finite": "^1.0.1"
             }
-        },
-        "numcodecs": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/numcodecs/-/numcodecs-0.2.2.tgz",
-            "integrity": "sha512-Y5K8mv80yb4MgVpcElBkUeMZqeE4TrovxRit/dTZvoRl6YkB6WEjY+fiUjGCblITnt3T3fmrDg8yRWu0gOLjhQ=="
         },
         "numeric": {
             "version": "1.2.6",
@@ -28856,11 +28229,6 @@
                 "repeat-string": "^1.3.0"
             }
         },
-        "pako": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
-            "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
-        },
         "param-case": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
@@ -28892,11 +28260,6 @@
             "version": "3.1.8",
             "resolved": "https://registry.npmjs.org/parenthesis/-/parenthesis-3.1.8.tgz",
             "integrity": "sha512-KF/U8tk54BgQewkJPvB4s/US3VQY68BRDpH638+7O/n58TpnwiwnOtGIOsT2/i+M78s61BBpeC83STB88d8sqw=="
-        },
-        "parse-headers": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.5.tgz",
-            "integrity": "sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA=="
         },
         "parse-json": {
             "version": "5.2.0",
@@ -30543,11 +29906,6 @@
             "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
             "dev": true
         },
-        "quick-lru": {
-            "version": "6.1.2",
-            "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.2.tgz",
-            "integrity": "sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ=="
-        },
         "quickselect": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
@@ -31380,20 +30738,6 @@
                 "prop-types": "^15.6.2"
             }
         },
-        "react-color": {
-            "version": "2.19.3",
-            "resolved": "https://registry.npmjs.org/react-color/-/react-color-2.19.3.tgz",
-            "integrity": "sha512-LEeGE/ZzNLIsFWa1TMe8y5VYqr7bibneWmvJwm1pCn/eNmrabWDh659JSPn9BuaMpEfU83WTOJfnCcjDZwNQTA==",
-            "requires": {
-                "@icons/material": "^0.2.4",
-                "lodash": "^4.17.15",
-                "lodash-es": "^4.17.15",
-                "material-colors": "^1.2.1",
-                "prop-types": "^15.5.10",
-                "reactcss": "^1.2.0",
-                "tinycolor2": "^1.4.1"
-            }
-        },
         "react-dom": {
             "version": "16.14.0",
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
@@ -31458,14 +30802,6 @@
                 "json2mq": "^0.2.0",
                 "lodash.debounce": "^4.0.8",
                 "resize-observer-polyfill": "^1.5.0"
-            }
-        },
-        "reactcss": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
-            "integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
-            "requires": {
-                "lodash": "^4.0.1"
             }
         },
         "readable-stream": {
@@ -31541,11 +30877,6 @@
                 "rxjs": "^5.5.11",
                 "symbol-observable": "^1.2.0"
             }
-        },
-        "reference-spec-reader": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/reference-spec-reader/-/reference-spec-reader-0.2.0.tgz",
-            "integrity": "sha512-q0mfCi5yZSSHXpCyxjgQeaORq3tvDsxDyzaadA/5+AbAUwRyRuuTh0aRQuE/vAOt/qzzxidJ5iDeu1cLHaNBlQ=="
         },
         "reflect.getprototypeof": {
             "version": "1.0.4",
@@ -32421,21 +31752,6 @@
             "resolved": "https://registry.npmjs.org/signum/-/signum-1.0.0.tgz",
             "integrity": "sha512-yodFGwcyt59XRh7w5W3jPcIQb3Bwi21suEfT7MAWnBX3iCdklJpgDgvGT9o04UonglZN5SNMfJFkHIR/jO8GHw=="
         },
-        "simple-swizzle": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-            "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
-            "requires": {
-                "is-arrayish": "^0.3.1"
-            },
-            "dependencies": {
-                "is-arrayish": {
-                    "version": "0.3.2",
-                    "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-                    "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
-                }
-            }
-        },
         "simplicial-complex": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/simplicial-complex/-/simplicial-complex-1.0.0.tgz",
@@ -32943,11 +32259,6 @@
             "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
             "dev": true
         },
-        "three": {
-            "version": "0.144.0",
-            "resolved": "https://registry.npmjs.org/three/-/three-0.144.0.tgz",
-            "integrity": "sha512-R8AXPuqfjfRJKkYoTQcTK7A6i3AdO9++2n8ubya/GTU+fEHhYKu1ZooRSCPkx69jbnzT7dD/xEo6eROQTt2lJw=="
-        },
         "through2": {
             "version": "0.6.5",
             "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
@@ -33280,11 +32591,6 @@
                 "gl-vec3": "^1.0.2"
             }
         },
-        "tweakpane": {
-            "version": "3.1.10",
-            "resolved": "https://registry.npmjs.org/tweakpane/-/tweakpane-3.1.10.tgz",
-            "integrity": "sha512-rqwnl/pUa7+inhI2E9ayGTqqP0EPOOn/wVvSWjZsRbZUItzNShny7pzwL3hVlaN4m9t/aZhsP0aFQ9U5VVR2VQ=="
-        },
         "tweetnacl": {
             "version": "0.14.5",
             "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
@@ -33481,14 +32787,6 @@
             "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
             "integrity": "sha512-vRCqFv6UhXpWxZPyGDh/F3ZpNv8/qo7w6iufLpQg9aKnQ71qM4B5KiI7Mia9COcjEhrO9LueHpMYjYzsWH3OIg=="
         },
-        "unzipit": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/unzipit/-/unzipit-1.4.3.tgz",
-            "integrity": "sha512-gsq2PdJIWWGhx5kcdWStvNWit9FVdTewm4SEG7gFskWs+XCVaULt9+BwuoBtJiRE8eo3L1IPAOrbByNLtLtIlg==",
-            "requires": {
-                "uzip-module": "^1.0.2"
-            }
-        },
         "update-browserslist-db": {
             "version": "1.0.13",
             "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
@@ -33559,11 +32857,6 @@
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
             "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
             "dev": true
-        },
-        "uzip-module": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/uzip-module/-/uzip-module-1.0.3.tgz",
-            "integrity": "sha512-AMqwWZaknLM77G+VPYNZLEruMGWGzyigPK3/Whg99B3S6vGHuqsyl5ZrOv1UUF3paGK1U6PM0cnayioaryg/fA=="
         },
         "v8-compile-cache-lib": {
             "version": "3.0.1",
@@ -33670,11 +32963,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/weakmap-shim/-/weakmap-shim-1.1.1.tgz",
             "integrity": "sha512-/wNyG+1FpiHhnfQo+TuA/XAUpvOOkKVl0A4qpT+oGcj5SlZCLmM+M1Py/3Sj8sy+YrEauCVITOxCsZKo6sPbQg=="
-        },
-        "web-worker": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.2.0.tgz",
-            "integrity": "sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA=="
         },
         "webgl-context": {
             "version": "2.2.0",
@@ -34168,11 +33456,6 @@
             "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
             "dev": true
         },
-        "xml-utils": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.7.0.tgz",
-            "integrity": "sha512-bWB489+RQQclC7A9OW8e5BzbT8Tu//jtAOvkYwewFr+Q9T9KDGvfzC1lp0pYPEQPEoPQLDkmxkepSC/2gIAZGw=="
-        },
         "xmlhttprequest": {
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
@@ -34231,16 +33514,6 @@
             "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
             "dev": true
         },
-        "zarrita": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/zarrita/-/zarrita-0.3.2.tgz",
-            "integrity": "sha512-Zx9nS28C2tXZhF1BmQkgQGi0M/Z5JiM/KCMa+fEYtr/MnIzyizR4sKRA/sXjDP1iuylILWTJAWWBJD//0ONXCA==",
-            "requires": {
-                "@zarrita/core": "^0.0.3",
-                "@zarrita/indexing": "^0.0.3",
-                "@zarrita/storage": "^0.0.2"
-            }
-        },
         "zero-crossings": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/zero-crossings/-/zero-crossings-1.0.1.tgz",
@@ -34248,11 +33521,6 @@
             "requires": {
                 "cwise-compiler": "^1.0.0"
             }
-        },
-        "zstddec": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.1.0.tgz",
-            "integrity": "sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg=="
         }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -93,10 +93,36 @@
                 "webpack-dev-server": "^4.7.3"
             }
         },
-        "../website-3d-cell-viewer": {
-            "name": "@aics/web-3d-viewer",
+        "node_modules/@aashutoshrathi/word-wrap": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+            "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/@aics/browsing-context-messaging": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@aics/browsing-context-messaging/-/browsing-context-messaging-1.1.0.tgz",
+            "integrity": "sha512-ts+Z8g/xTJaD+g9fAElEJbclk1L0xDsHy6ioq9N5T4j5WPew46WvZ/794Vxnn9N06KyjkCO6zc4JEl7ZZRSa5Q=="
+        },
+        "node_modules/@aics/volume-viewer": {
+            "version": "3.9.0",
+            "resolved": "https://registry.npmjs.org/@aics/volume-viewer/-/volume-viewer-3.9.0.tgz",
+            "integrity": "sha512-+ftd8aArxi/ICMqrkuGf2Cq98bb4heM4tdy6iyN2B+by9adLKqeIfyaNGcW/WlePeCD9oxV+rdICvlKnNBLM4w==",
+            "dependencies": {
+                "geotiff": "^2.0.5",
+                "serialize-error": "^11.0.3",
+                "three": "^0.144.0",
+                "tweakpane": "^3.1.9",
+                "zarrita": "^0.3.2"
+            }
+        },
+        "node_modules/@aics/web-3d-viewer": {
             "version": "2.9.0",
-            "license": "ISC",
+            "resolved": "https://registry.npmjs.org/@aics/web-3d-viewer/-/web-3d-viewer-2.9.0.tgz",
+            "integrity": "sha512-grGrc8v1cvBmSpGp/s2tqjpkUMrdNLoHu+zXch0A9SFJZQSXDj6cKvrxG0PEqt6CJK8e/Cvturv6GuzGkT+Rig==",
             "dependencies": {
                 "@aics/volume-viewer": "^3.9.0",
                 "@ant-design/icons": "^5.2.5",
@@ -113,91 +139,38 @@
                 "styled-components": "^6.1.8",
                 "usehooks-ts": "^3.1.0"
             },
-            "devDependencies": {
-                "@babel/cli": "^7.14.5",
-                "@babel/core": "^7.14.6",
-                "@babel/preset-env": "^7.23.3",
-                "@babel/preset-react": "^7.14.5",
-                "@babel/preset-typescript": "^7.14.5",
-                "@babel/runtime": "^7.14.6",
-                "@dr.pogodin/babel-preset-svgr": "^1.8.0",
-                "@types/color-string": "^1.5.2",
-                "@types/d3": "^4.13.12",
-                "@types/jest": "^27.4.0",
-                "@types/lodash": "^4.14.185",
-                "@types/react": "^16.x",
-                "@types/react-color": "^3.0.6",
-                "@types/react-dom": "^16.x",
-                "@typescript-eslint/eslint-plugin": "^5.31.0",
-                "@typescript-eslint/parser": "^5.31.0",
-                "antd": "^5.16.2",
-                "axios": "^0.21.1",
-                "babel-loader": "^8.2.2",
-                "babel-plugin-replace-import-extension": "^1.1.3",
-                "clean-webpack-plugin": "^4.0.0-alpha.0",
-                "command-line-args": "^5.1.1",
-                "copy-webpack-plugin": "^11.0.0",
-                "cross-env": "^7.0.3",
-                "css-loader": "^6.2.0",
-                "esbuild": "^0.14.50",
-                "esbuild-jest": "^0.5.0",
-                "eslint": "^8.20.0",
-                "eslint-plugin-react": "^7.30.1",
-                "file-loader": "^6.2.0",
-                "firebase": "^7.15.3",
-                "gh-pages": "^4.0.0",
-                "html-webpack-plugin": "^5.3.2",
-                "jest": "^27.0.6",
-                "mini-css-extract-plugin": "^2.2.0",
-                "morgan": "^1.9.1",
-                "npm-run-all": "^4.1.5",
-                "postcss": "^8.4.31",
-                "postcss-cli": "^8.3.1",
-                "postcss-discard-comments": "^5.0.1",
-                "postcss-extend-rule": "^3.0.0",
-                "postcss-import": "^14.0.2",
-                "postcss-loader": "^6.1.1",
-                "postcss-mixins": "^8.1.0",
-                "postcss-nested": "^5.0.6",
-                "postcss-simple-vars": "^6.0.3",
-                "postcss-url": "^10.1.3",
-                "prop-types": "^15.5.10",
-                "react": "^16.12.0",
-                "react-dom": "^16.12.0",
-                "resolve-url-loader": "^5.0.0",
-                "style-loader": "^3.2.1",
-                "ts-jest": "^27.1.2",
-                "typescript": "^4.3.5",
-                "url-loader": "^4.1.1",
-                "webpack": "^5.89.0",
-                "webpack-cli": "^4.7.2",
-                "webpack-dev-server": "^4.9.3",
-                "webpack-merge": "^5.8.0",
-                "webpack-shell-plugin": "^0.5.0"
-            },
             "peerDependencies": {
                 "antd": "^5.16.2",
                 "react": "16.x",
                 "react-dom": "16.x"
             }
         },
-        "node_modules/@aashutoshrathi/word-wrap": {
-            "version": "1.2.6",
-            "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
-            "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
+        "node_modules/@aics/web-3d-viewer/node_modules/@ant-design/colors": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-7.0.2.tgz",
+            "integrity": "sha512-7KJkhTiPiLHSu+LmMJnehfJ6242OCxSlR3xHVBecYxnMW8MS/878NXct1GqYARyL59fyeFdKRxXTfvR9SnDgJg==",
+            "dependencies": {
+                "@ctrl/tinycolor": "^3.6.1"
             }
         },
-        "node_modules/@aics/browsing-context-messaging": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@aics/browsing-context-messaging/-/browsing-context-messaging-1.1.0.tgz",
-            "integrity": "sha512-ts+Z8g/xTJaD+g9fAElEJbclk1L0xDsHy6ioq9N5T4j5WPew46WvZ/794Vxnn9N06KyjkCO6zc4JEl7ZZRSa5Q=="
-        },
-        "node_modules/@aics/web-3d-viewer": {
-            "resolved": "../website-3d-cell-viewer",
-            "link": true
+        "node_modules/@aics/web-3d-viewer/node_modules/@ant-design/icons": {
+            "version": "5.3.7",
+            "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-5.3.7.tgz",
+            "integrity": "sha512-bCPXTAg66f5bdccM4TT21SQBDO1Ek2gho9h3nO9DAKXJP4sq+5VBjrQMSxMVXSB3HyEz+cUbHQ5+6ogxCOpaew==",
+            "dependencies": {
+                "@ant-design/colors": "^7.0.0",
+                "@ant-design/icons-svg": "^4.4.0",
+                "@babel/runtime": "^7.11.2",
+                "classnames": "^2.2.6",
+                "rc-util": "^5.31.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "peerDependencies": {
+                "react": ">=16.0.0",
+                "react-dom": ">=16.0.0"
+            }
         },
         "node_modules/@ampproject/remapping": {
             "version": "2.2.1",
@@ -259,9 +232,9 @@
             }
         },
         "node_modules/@ant-design/icons-svg": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/@ant-design/icons-svg/-/icons-svg-4.3.1.tgz",
-            "integrity": "sha512-4QBZg8ccyC6LPIRii7A0bZUk3+lEDCLnhB+FVsflGdcWPPmV+j3fire4AwwoqHV/BibgvBmR9ZIo4s867smv+g=="
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/@ant-design/icons-svg/-/icons-svg-4.4.2.tgz",
+            "integrity": "sha512-vHbT+zJEVzllwP+CM+ul7reTEfBR0vgxFe7+lREAsAA7YGsYpboiq2sQNeQeRvh09GfQgs/GyFEvZpJ9cLXpXA=="
         },
         "node_modules/@babel/code-frame": {
             "version": "7.23.5",
@@ -2165,6 +2138,24 @@
                 "node": ">=10.0.0"
             }
         },
+        "node_modules/@emotion/is-prop-valid": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz",
+            "integrity": "sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==",
+            "dependencies": {
+                "@emotion/memoize": "^0.8.1"
+            }
+        },
+        "node_modules/@emotion/memoize": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
+            "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
+        },
+        "node_modules/@emotion/unitless": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
+            "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ=="
+        },
         "node_modules/@eslint-community/eslint-utils": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -2545,6 +2536,51 @@
             "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.4.0.tgz",
             "integrity": "sha512-8cUA/mg0S+BxIZ72TdZRsXKBP5n5uRcE3k29TZhZw6oIiHBt9JA7CTb/4pE1uKtE/q5NeTY2tBDcagoZ+1zjXQ=="
         },
+        "node_modules/@fortawesome/fontawesome-common-types": {
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.5.2.tgz",
+            "integrity": "sha512-gBxPg3aVO6J0kpfHNILc+NMhXnqHumFxOmjYCFfOiLZfwhnnfhtsdA2hfJlDnj+8PjAs6kKQPenOTKj3Rf7zHw==",
+            "hasInstallScript": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/@fortawesome/fontawesome-svg-core": {
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.5.2.tgz",
+            "integrity": "sha512-5CdaCBGl8Rh9ohNdxeeTMxIj8oc3KNBgIeLMvJosBMdslK/UnEB8rzyDRrbKdL1kDweqBPo4GT9wvnakHWucZw==",
+            "hasInstallScript": true,
+            "dependencies": {
+                "@fortawesome/fontawesome-common-types": "6.5.2"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/@fortawesome/free-solid-svg-icons": {
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.5.2.tgz",
+            "integrity": "sha512-QWFZYXFE7O1Gr1dTIp+D6UcFUF0qElOnZptpi7PBUMylJh+vFmIedVe1Ir6RM1t2tEQLLSV1k7bR4o92M+uqlw==",
+            "hasInstallScript": true,
+            "dependencies": {
+                "@fortawesome/fontawesome-common-types": "6.5.2"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/@fortawesome/react-fontawesome": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.2.tgz",
+            "integrity": "sha512-EnkrprPNqI6SXJl//m29hpaNzOp1bruISWaOiRtkMi/xSvHJlzc2j2JAYS7egxt/EbjSNV/k6Xy0AQI6vB2+1g==",
+            "dependencies": {
+                "prop-types": "^15.8.1"
+            },
+            "peerDependencies": {
+                "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+                "react": ">=16.3"
+            }
+        },
         "node_modules/@grpc/grpc-js": {
             "version": "1.9.13",
             "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.13.tgz",
@@ -2646,6 +2682,14 @@
             "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
             "integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
             "dev": true
+        },
+        "node_modules/@icons/material": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
+            "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==",
+            "peerDependencies": {
+                "react": "*"
+            }
         },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.3.3",
@@ -2818,6 +2862,11 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/@petamoriken/float16": {
+            "version": "3.8.7",
+            "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.8.7.tgz",
+            "integrity": "sha512-/Ri4xDDpe12NT6Ex/DRgHzLlobiQXEW/hmG08w1wj/YU7hLemk97c+zHQFp0iZQ9r7YqgLEXZR2sls4HxBf9NA=="
+        },
         "node_modules/@plotly/d3-sankey": {
             "version": "0.7.2",
             "resolved": "https://registry.npmjs.org/@plotly/d3-sankey/-/d3-sankey-0.7.2.tgz",
@@ -2915,6 +2964,14 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
             "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+        },
+        "node_modules/@remix-run/router": {
+            "version": "1.16.1",
+            "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.16.1.tgz",
+            "integrity": "sha512-es2g3dq6Nb07iFxGk5GuHN20RwBZOsuDQN7izWIisUcv9r+d2C5jQxqmgkdebXgReWfiyUabcki6Fg77mSNrig==",
+            "engines": {
+                "node": ">=14.0.0"
+            }
         },
         "node_modules/@sinonjs/commons": {
             "version": "1.8.6",
@@ -3461,6 +3518,11 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@types/stylis": {
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.5.tgz",
+            "integrity": "sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw=="
+        },
         "node_modules/@types/tough-cookie": {
             "version": "4.0.5",
             "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
@@ -3962,6 +4024,40 @@
             "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
             "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
             "dev": true
+        },
+        "node_modules/@zarrita/core": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/@zarrita/core/-/core-0.0.3.tgz",
+            "integrity": "sha512-fWv51b+xbYnws1pkNDPwJQoDa76aojxplHyMup82u11UAiet3gURMsrrkhM6YbeTgSY1A8oGxDOrvar3SiZpLA==",
+            "dependencies": {
+                "@zarrita/storage": "^0.0.2",
+                "@zarrita/typedarray": "^0.0.1",
+                "numcodecs": "^0.2.2"
+            }
+        },
+        "node_modules/@zarrita/indexing": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/@zarrita/indexing/-/indexing-0.0.3.tgz",
+            "integrity": "sha512-Q61d9MYX6dsK1DLltEpwx4mJWCZHj0TXiaEN4QpxNDtToa/EoyytP/pYHPypO4GXBscZooJ6eZkKT5FMx9PVfg==",
+            "dependencies": {
+                "@zarrita/core": "^0.0.3",
+                "@zarrita/storage": "^0.0.2",
+                "@zarrita/typedarray": "^0.0.1"
+            }
+        },
+        "node_modules/@zarrita/storage": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/@zarrita/storage/-/storage-0.0.2.tgz",
+            "integrity": "sha512-uFt4abAoiOYLroalNDAnVaQxA17zGKrQ0waYKmTVm+bNonz8ggKZP+0FqMhgUZITGChqoANHuYTazbuU5AFXWA==",
+            "dependencies": {
+                "reference-spec-reader": "^0.2.0",
+                "unzipit": "^1.3.6"
+            }
+        },
+        "node_modules/@zarrita/typedarray": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/@zarrita/typedarray/-/typedarray-0.0.1.tgz",
+            "integrity": "sha512-ZdvNjYP1bEuQXoSTVkemV99w42jHYrJ3nh9golCLd4MVBlrVbfZo4wWgBslU4JZUaDikhFSH+GWMDgAq/rI32g=="
         },
         "node_modules/3d-view": {
             "version": "2.0.1",
@@ -5065,6 +5161,14 @@
             "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
             "dev": true
         },
+        "node_modules/camelize": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+            "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/caniuse-lite": {
             "version": "1.0.30001570",
             "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001570.tgz",
@@ -5430,6 +5534,15 @@
             "dependencies": {
                 "hsluv": "^0.0.3",
                 "mumath": "^3.3.4"
+            }
+        },
+        "node_modules/color-string": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+            "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+            "dependencies": {
+                "color-name": "^1.0.0",
+                "simple-swizzle": "^0.2.2"
             }
         },
         "node_modules/colorette": {
@@ -5805,6 +5918,14 @@
                 "url": "https://opencollective.com/postcss/"
             }
         },
+        "node_modules/css-color-keywords": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+            "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/css-font": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/css-font/-/css-font-1.2.0.tgz",
@@ -6029,6 +6150,16 @@
             "resolved": "https://registry.npmjs.org/css-system-font-keywords/-/css-system-font-keywords-1.0.0.tgz",
             "integrity": "sha512-1umTtVd/fXS25ftfjB71eASCrYhilmEsvDEI6wG/QplnmlfmVM5HkZ/ZX46DT5K3eblFPgLUHt5BRCb0YXkSFA=="
         },
+        "node_modules/css-to-react-native": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+            "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+            "dependencies": {
+                "camelize": "^1.0.0",
+                "css-color-keywords": "^1.0.0",
+                "postcss-value-parser": "^4.0.2"
+            }
+        },
         "node_modules/css-what": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
@@ -6106,10 +6237,73 @@
                 "type": "^1.0.1"
             }
         },
+        "node_modules/d3": {
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/d3/-/d3-4.13.0.tgz",
+            "integrity": "sha512-l8c4+0SldjVKLaE2WG++EQlqD7mh/dmQjvi2L2lKPadAVC+TbJC4ci7Uk9bRi+To0+ansgsS0iWfPjD7DBy+FQ==",
+            "dependencies": {
+                "d3-array": "1.2.1",
+                "d3-axis": "1.0.8",
+                "d3-brush": "1.0.4",
+                "d3-chord": "1.0.4",
+                "d3-collection": "1.0.4",
+                "d3-color": "1.0.3",
+                "d3-dispatch": "1.0.3",
+                "d3-drag": "1.2.1",
+                "d3-dsv": "1.0.8",
+                "d3-ease": "1.0.3",
+                "d3-force": "1.1.0",
+                "d3-format": "1.2.2",
+                "d3-geo": "1.9.1",
+                "d3-hierarchy": "1.1.5",
+                "d3-interpolate": "1.1.6",
+                "d3-path": "1.0.5",
+                "d3-polygon": "1.0.3",
+                "d3-quadtree": "1.0.3",
+                "d3-queue": "3.0.7",
+                "d3-random": "1.1.0",
+                "d3-request": "1.0.6",
+                "d3-scale": "1.0.7",
+                "d3-selection": "1.3.0",
+                "d3-shape": "1.2.0",
+                "d3-time": "1.0.8",
+                "d3-time-format": "2.1.1",
+                "d3-timer": "1.0.7",
+                "d3-transition": "1.1.1",
+                "d3-voronoi": "1.1.2",
+                "d3-zoom": "1.7.1"
+            }
+        },
         "node_modules/d3-array": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.1.tgz",
             "integrity": "sha512-CyINJQ0SOUHojDdFDH4JEM0552vCR1utGyLHegJHyYH0JyCpSeTPxi4OBqHMA2jJZq4NH782LtaJWBImqI/HBw=="
+        },
+        "node_modules/d3-axis": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-1.0.8.tgz",
+            "integrity": "sha512-K0djTb26iQ6AsuD2d6Ka08wBHf4V30awIxV4XFuB/iLzYtTqqJlE/nIN0DBJJCX7lbOqbt2/oeX3r+sU5k2veg=="
+        },
+        "node_modules/d3-brush": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-1.0.4.tgz",
+            "integrity": "sha512-nUFueDzOlvwFvuOBynGSyJM7Wt1H9fKgJeoWFSg3ScS4c7FJBch92FKUJKum4xtgPYHdgH2C3bRg3GzSVltCJQ==",
+            "dependencies": {
+                "d3-dispatch": "1",
+                "d3-drag": "1",
+                "d3-interpolate": "1",
+                "d3-selection": "1",
+                "d3-transition": "1"
+            }
+        },
+        "node_modules/d3-chord": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-1.0.4.tgz",
+            "integrity": "sha512-o0ExexkK1N0KikUakKrQwttP5Flu8AYD6iBUh3AdPJqnTh6xlvcX5wFRuuo29sLOAr9+T4yZPUH1S3CCQJ1SlQ==",
+            "dependencies": {
+                "d3-array": "1",
+                "d3-path": "1"
+            }
         },
         "node_modules/d3-collection": {
             "version": "1.0.4",
@@ -6126,15 +6320,132 @@
             "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.3.tgz",
             "integrity": "sha512-Qh2DR3neW3lq/ug4oymXHYoIsA91nYt47ERb+fPKjRg6zLij06aP7KqHHl2NyziK9ASxrR3GLkHCtZvXe/jMVg=="
         },
+        "node_modules/d3-drag": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-1.2.1.tgz",
+            "integrity": "sha512-Cg8/K2rTtzxzrb0fmnYOUeZHvwa4PHzwXOLZZPwtEs2SKLLKLXeYwZKBB+DlOxUvFmarOnmt//cU4+3US2lyyQ==",
+            "dependencies": {
+                "d3-dispatch": "1",
+                "d3-selection": "1"
+            }
+        },
+        "node_modules/d3-dsv": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-1.0.8.tgz",
+            "integrity": "sha512-IVCJpQ+YGe3qu6odkPQI0KPqfxkhbP/oM1XhhE/DFiYmcXKfCRub4KXyiuehV1d4drjWVXHUWx4gHqhdZb6n/A==",
+            "dependencies": {
+                "commander": "2",
+                "iconv-lite": "0.4",
+                "rw": "1"
+            },
+            "bin": {
+                "csv2json": "bin/dsv2json",
+                "csv2tsv": "bin/dsv2dsv",
+                "dsv2dsv": "bin/dsv2dsv",
+                "dsv2json": "bin/dsv2json",
+                "json2csv": "bin/json2dsv",
+                "json2dsv": "bin/json2dsv",
+                "json2tsv": "bin/json2dsv",
+                "tsv2csv": "bin/dsv2dsv",
+                "tsv2json": "bin/dsv2json"
+            }
+        },
+        "node_modules/d3-ease": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.3.tgz",
+            "integrity": "sha512-io3QwOJwVPAxRF2UXpKpCdz2wm/7VLFCQQ1yy+GzX6YCtt3vi2BGnimI8agSF5jyUrHsADyF303d2S+ps7zU8w=="
+        },
+        "node_modules/d3-force": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.1.0.tgz",
+            "integrity": "sha512-2HVQz3/VCQs0QeRNZTYb7GxoUCeb6bOzMp/cGcLa87awY9ZsPvXOGeZm0iaGBjXic6I1ysKwMn+g+5jSAdzwcg==",
+            "dependencies": {
+                "d3-collection": "1",
+                "d3-dispatch": "1",
+                "d3-quadtree": "1",
+                "d3-timer": "1"
+            }
+        },
+        "node_modules/d3-format": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.2.2.tgz",
+            "integrity": "sha512-zH9CfF/3C8zUI47nsiKfD0+AGDEuM8LwBIP7pBVpyR4l/sKkZqITmMtxRp04rwBrlshIZ17XeFAaovN3++wzkw=="
+        },
+        "node_modules/d3-geo": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.9.1.tgz",
+            "integrity": "sha512-l9wL/cEQkyZQYXw3xbmLsH3eQ5ij+icNfo4r0GrLa5rOCZR/e/3am45IQ0FvQ5uMsv+77zBRunLc9ufTWSQYFA==",
+            "dependencies": {
+                "d3-array": "1"
+            }
+        },
+        "node_modules/d3-hierarchy": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-1.1.5.tgz",
+            "integrity": "sha512-PcsLIhThc60mWnxlojIOH7Sc0tQ2DgLWfEwEAyzCtej5f3H9wSsRmrg5pEhKZLrwiJnI2zyw/pznJxL9a/Eugw=="
+        },
+        "node_modules/d3-interpolate": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.1.6.tgz",
+            "integrity": "sha512-mOnv5a+pZzkNIHtw/V6I+w9Lqm9L5bG3OTXPM5A+QO0yyVMQ4W1uZhR+VOJmazaOZXri2ppbiZ5BUNWT0pFM9A==",
+            "dependencies": {
+                "d3-color": "1"
+            }
+        },
         "node_modules/d3-path": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.5.tgz",
             "integrity": "sha512-eD76prgnTKYkLzHlY2UMyOEZXTpC+WOanCr1BLxo38w4fPPPq/LgCFqRQvqFU3AJngfZmmKR7rgKPZ4EGJ9Atw=="
         },
+        "node_modules/d3-polygon": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-1.0.3.tgz",
+            "integrity": "sha512-2zP7GOvf4XOWTeQouK7fCO534yQxyhYYTw6GTqcXifIalHgA6qV/es+4GRQii9m6XxEPFcht4loobD/o2iEo1A=="
+        },
         "node_modules/d3-quadtree": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-1.0.3.tgz",
             "integrity": "sha512-U2Jc3jF3JOBGXIOnvWY9C4ekRwRX9hEVpMMmeduJyaxAwPmoe7t84iZFTLn1RwYOyrXxJF55H/Hrg186TFQQdw=="
+        },
+        "node_modules/d3-queue": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/d3-queue/-/d3-queue-3.0.7.tgz",
+            "integrity": "sha512-2rs+6pNFKkrJhqe1rg5znw7dKJ7KZr62j9aLZfhondkrnz6U7VRmJj1UGcbD8MRc46c7H8m4SWhab8EalBQrkw=="
+        },
+        "node_modules/d3-random": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-1.1.0.tgz",
+            "integrity": "sha512-XuMbjx3Jq4EWfJP4g6nR7zns/bZfaVbWHWfR8auDkEiWCzVbWifmasfszV1ZRN3xXK3nY4RUFL2nTIhceGZSFQ=="
+        },
+        "node_modules/d3-request": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/d3-request/-/d3-request-1.0.6.tgz",
+            "integrity": "sha512-FJj8ySY6GYuAJHZMaCQ83xEYE4KbkPkmxZ3Hu6zA1xxG2GD+z6P+Lyp+zjdsHf0xEbp2xcluDI50rCS855EQ6w==",
+            "dependencies": {
+                "d3-collection": "1",
+                "d3-dispatch": "1",
+                "d3-dsv": "1",
+                "xmlhttprequest": "1"
+            }
+        },
+        "node_modules/d3-scale": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+            "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+            "dependencies": {
+                "d3-array": "^1.2.0",
+                "d3-collection": "1",
+                "d3-color": "1",
+                "d3-format": "1",
+                "d3-interpolate": "1",
+                "d3-time": "1",
+                "d3-time-format": "2"
+            }
+        },
+        "node_modules/d3-selection": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.3.0.tgz",
+            "integrity": "sha512-qgpUOg9tl5CirdqESUAu0t9MU/t3O9klYfGfyKsXEmhyxyzLpzpeh08gaxBUTQw1uXIOkr/30Ut2YRjSSxlmHA=="
         },
         "node_modules/d3-shape": {
             "version": "1.2.0",
@@ -6149,10 +6460,48 @@
             "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.0.8.tgz",
             "integrity": "sha512-YRZkNhphZh3KcnBfitvF3c6E0JOFGikHZ4YqD+Lzv83ZHn1/u6yGenRU1m+KAk9J1GnZMnKcrtfvSktlA1DXNQ=="
         },
+        "node_modules/d3-time-format": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.1.1.tgz",
+            "integrity": "sha512-8kAkymq2WMfzW7e+s/IUNAtN/y3gZXGRrdGfo6R8NKPAA85UBTxZg5E61bR6nLwjPjj4d3zywSQe1CkYLPFyrw==",
+            "dependencies": {
+                "d3-time": "1"
+            }
+        },
         "node_modules/d3-timer": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.7.tgz",
             "integrity": "sha512-vMZXR88XujmG/L5oB96NNKH5lCWwiLM/S2HyyAQLcjWJCloK5shxta4CwOFYLZoY3AWX73v8Lgv4cCAdWtRmOA=="
+        },
+        "node_modules/d3-transition": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-1.1.1.tgz",
+            "integrity": "sha512-xeg8oggyQ+y5eb4J13iDgKIjUcEfIOZs2BqV/eEmXm2twx80wTzJ4tB4vaZ5BKfz7XsI/DFmQL5me6O27/5ykQ==",
+            "dependencies": {
+                "d3-color": "1",
+                "d3-dispatch": "1",
+                "d3-ease": "1",
+                "d3-interpolate": "1",
+                "d3-selection": "^1.1.0",
+                "d3-timer": "1"
+            }
+        },
+        "node_modules/d3-voronoi": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.2.tgz",
+            "integrity": "sha512-RhGS1u2vavcO7ay7ZNAPo4xeDh/VYeGof3x5ZLJBQgYhLegxr3s5IykvWmJ94FTU6mcbtp4sloqZ54mP6R4Utw=="
+        },
+        "node_modules/d3-zoom": {
+            "version": "1.7.1",
+            "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-1.7.1.tgz",
+            "integrity": "sha512-sZHQ55DGq5BZBFGnRshUT8tm2sfhPHFnOlmPbbwTkAoPeVdRTkB4Xsf9GCY0TSHrTD8PeJPZGmP/TpGicwJDJQ==",
+            "dependencies": {
+                "d3-dispatch": "1",
+                "d3-drag": "1",
+                "d3-interpolate": "1",
+                "d3-selection": "1",
+                "d3-transition": "1"
+            }
         },
         "node_modules/dashdash": {
             "version": "1.14.1",
@@ -8331,6 +8680,14 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/fuse.js": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.0.0.tgz",
+            "integrity": "sha512-14F4hBIxqKvD4Zz/XjDc3y94mNZN6pRv3U13Udo0lNLCWRBUsrMv2xwcF/y/Z5sV6+FQW+/ow68cHpm4sunt8Q==",
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/gamma": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/gamma/-/gamma-0.1.0.tgz",
@@ -8349,6 +8706,24 @@
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.1.tgz",
             "integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg=="
+        },
+        "node_modules/geotiff": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.1.3.tgz",
+            "integrity": "sha512-PT6uoF5a1+kbC3tHmZSUsLHBp2QJlHasxxxxPW47QIY1VBKpFB+FcDvX+MxER6UzgLQZ0xDzJ9s48B9JbOCTqA==",
+            "dependencies": {
+                "@petamoriken/float16": "^3.4.7",
+                "lerc": "^3.0.0",
+                "pako": "^2.0.4",
+                "parse-headers": "^2.0.2",
+                "quick-lru": "^6.1.1",
+                "web-worker": "^1.2.0",
+                "xml-utils": "^1.0.2",
+                "zstddec": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=10.19"
+            }
         },
         "node_modules/get-caller-file": {
             "version": "2.0.5",
@@ -9584,7 +9959,6 @@
             "version": "0.4.24",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
             "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-            "dev": true,
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3"
             },
@@ -10647,6 +11021,11 @@
             "deprecated": "use String.prototype.padStart()",
             "dev": true
         },
+        "node_modules/lerc": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
+            "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww=="
+        },
         "node_modules/lerp": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/lerp/-/lerp-1.0.3.tgz",
@@ -10814,8 +11193,7 @@
         "node_modules/lodash-es": {
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-            "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-            "dev": true
+            "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
         },
         "node_modules/lodash.camelcase": {
             "version": "4.3.0",
@@ -11037,6 +11415,11 @@
             "dependencies": {
                 "gl-mat4": "^1.0.1"
             }
+        },
+        "node_modules/material-colors": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
+            "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
         },
         "node_modules/math-log2": {
             "version": "1.0.1",
@@ -11495,7 +11878,6 @@
             "version": "3.3.7",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
             "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -11766,6 +12148,23 @@
             "resolved": "https://registry.npmjs.org/normals/-/normals-1.1.0.tgz",
             "integrity": "sha512-XWeliW48BLvbVJ+cjQAOE+tA0m1M7Yi1iTPphAS9tBmW1A/c/cOVnEUecPCCMH5lEAihAcG6IRle56ls9k3xug=="
         },
+        "node_modules/nouislider": {
+            "version": "14.7.0",
+            "resolved": "https://registry.npmjs.org/nouislider/-/nouislider-14.7.0.tgz",
+            "integrity": "sha512-4RtQ1+LHJKesDCNJrXkQcwXAWCrC2aggdLYMstS/G5fEWL+fXZbUA9pwVNHFghMGuFGRATlDLNInRaPeRKzpFQ=="
+        },
+        "node_modules/nouislider-react": {
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/nouislider-react/-/nouislider-react-3.4.2.tgz",
+            "integrity": "sha512-7YsyHY/j7yxaoNzt4PGZMoJLdh/e8aY5rYZ5xxpBv9LAs/gqt+M/Lk9SAi05+XF4mI749B2ISZjHdEIZUMWY6g==",
+            "dependencies": {
+                "nouislider": "^14.6.3"
+            },
+            "peerDependencies": {
+                "nouislider": ">= 11.x",
+                "react": ">= 16.8.x"
+            }
+        },
         "node_modules/npm-run-path": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -11805,6 +12204,14 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/numcodecs": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/numcodecs/-/numcodecs-0.2.2.tgz",
+            "integrity": "sha512-Y5K8mv80yb4MgVpcElBkUeMZqeE4TrovxRit/dTZvoRl6YkB6WEjY+fiUjGCblITnt3T3fmrDg8yRWu0gOLjhQ==",
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/numeric": {
@@ -12129,6 +12536,11 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/pako": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+            "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
+        },
         "node_modules/param-case": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
@@ -12161,6 +12573,11 @@
             "version": "3.1.8",
             "resolved": "https://registry.npmjs.org/parenthesis/-/parenthesis-3.1.8.tgz",
             "integrity": "sha512-KF/U8tk54BgQewkJPvB4s/US3VQY68BRDpH638+7O/n58TpnwiwnOtGIOsT2/i+M78s61BBpeC83STB88d8sqw=="
+        },
+        "node_modules/parse-headers": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.5.tgz",
+            "integrity": "sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA=="
         },
         "node_modules/parse-json": {
             "version": "5.2.0",
@@ -12376,8 +12793,7 @@
         "node_modules/picocolors": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-            "dev": true
+            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
         },
         "node_modules/picomatch": {
             "version": "2.3.1",
@@ -12662,10 +13078,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.4.32",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz",
-            "integrity": "sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==",
-            "dev": true,
+            "version": "8.4.38",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
+            "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -12683,7 +13098,7 @@
             "dependencies": {
                 "nanoid": "^3.3.7",
                 "picocolors": "^1.0.0",
-                "source-map-js": "^1.0.2"
+                "source-map-js": "^1.2.0"
             },
             "engines": {
                 "node": "^10 || ^12 || >=14"
@@ -14029,8 +14444,7 @@
         "node_modules/postcss-value-parser": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-            "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-            "dev": true
+            "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
         },
         "node_modules/postcss-values-parser": {
             "version": "2.0.1",
@@ -14240,6 +14654,17 @@
                     "url": "https://feross.org/support"
                 }
             ]
+        },
+        "node_modules/quick-lru": {
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.2.tgz",
+            "integrity": "sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ==",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/quickselect": {
             "version": "2.0.0",
@@ -15086,6 +15511,23 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/react-color": {
+            "version": "2.19.3",
+            "resolved": "https://registry.npmjs.org/react-color/-/react-color-2.19.3.tgz",
+            "integrity": "sha512-LEeGE/ZzNLIsFWa1TMe8y5VYqr7bibneWmvJwm1pCn/eNmrabWDh659JSPn9BuaMpEfU83WTOJfnCcjDZwNQTA==",
+            "dependencies": {
+                "@icons/material": "^0.2.4",
+                "lodash": "^4.17.15",
+                "lodash-es": "^4.17.15",
+                "material-colors": "^1.2.1",
+                "prop-types": "^15.5.10",
+                "reactcss": "^1.2.0",
+                "tinycolor2": "^1.4.1"
+            },
+            "peerDependencies": {
+                "react": "*"
+            }
+        },
         "node_modules/react-dom": {
             "version": "16.14.0",
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
@@ -15155,6 +15597,36 @@
                 "redux": "^2.0.0 || ^3.0.0 || ^4.0.0-0"
             }
         },
+        "node_modules/react-router": {
+            "version": "6.23.1",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.23.1.tgz",
+            "integrity": "sha512-fzcOaRF69uvqbbM7OhvQyBTFDVrrGlsFdS3AL+1KfIBtGETibHzi3FkoTRyiDJnWNc2VxrfvR+657ROHjaNjqQ==",
+            "dependencies": {
+                "@remix-run/router": "1.16.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8"
+            }
+        },
+        "node_modules/react-router-dom": {
+            "version": "6.23.1",
+            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.23.1.tgz",
+            "integrity": "sha512-utP+K+aSTtEdbWpC+4gxhdlPFwuEfDKq8ZrPFU65bbRJY+l706qjR7yaidBpo3MSeA/fzwbXWbKBI6ftOnP3OQ==",
+            "dependencies": {
+                "@remix-run/router": "1.16.1",
+                "react-router": "6.23.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8",
+                "react-dom": ">=16.8"
+            }
+        },
         "node_modules/react-slick": {
             "version": "0.25.2",
             "resolved": "https://registry.npmjs.org/react-slick/-/react-slick-0.25.2.tgz",
@@ -15169,6 +15641,14 @@
             "peerDependencies": {
                 "react": "^0.14.0 || ^15.0.1 || ^16.0.0",
                 "react-dom": "^0.14.0 || ^15.0.1 || ^16.0.0"
+            }
+        },
+        "node_modules/reactcss": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
+            "integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
+            "dependencies": {
+                "lodash": "^4.0.1"
             }
         },
         "node_modules/readable-stream": {
@@ -15251,6 +15731,11 @@
             "peerDependencies": {
                 "redux": ">=3.5.2"
             }
+        },
+        "node_modules/reference-spec-reader": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/reference-spec-reader/-/reference-spec-reader-0.2.0.tgz",
+            "integrity": "sha512-q0mfCi5yZSSHXpCyxjgQeaORq3tvDsxDyzaadA/5+AbAUwRyRuuTh0aRQuE/vAOt/qzzxidJ5iDeu1cLHaNBlQ=="
         },
         "node_modules/reflect.getprototypeof": {
             "version": "1.0.4",
@@ -16093,6 +16578,31 @@
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "dev": true
         },
+        "node_modules/serialize-error": {
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-11.0.3.tgz",
+            "integrity": "sha512-2G2y++21dhj2R7iHAdd0FIzjGwuKZld+7Pl/bTU6YIkrC2ZMbVUjm+luj6A6V34Rv9XfKJDKpTWu9W4Gse1D9g==",
+            "dependencies": {
+                "type-fest": "^2.12.2"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/serialize-error/node_modules/type-fest": {
+            "version": "2.19.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+            "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+            "engines": {
+                "node": ">=12.20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/serialize-javascript": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
@@ -16315,6 +16825,19 @@
             "resolved": "https://registry.npmjs.org/signum/-/signum-1.0.0.tgz",
             "integrity": "sha512-yodFGwcyt59XRh7w5W3jPcIQb3Bwi21suEfT7MAWnBX3iCdklJpgDgvGT9o04UonglZN5SNMfJFkHIR/jO8GHw=="
         },
+        "node_modules/simple-swizzle": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+            "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+            "dependencies": {
+                "is-arrayish": "^0.3.1"
+            }
+        },
+        "node_modules/simple-swizzle/node_modules/is-arrayish": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+            "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+        },
         "node_modules/simplicial-complex": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/simplicial-complex/-/simplicial-complex-1.0.0.tgz",
@@ -16452,10 +16975,9 @@
             }
         },
         "node_modules/source-map-js": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-            "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-            "dev": true,
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+            "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -16749,6 +17271,43 @@
                 "webpack": "^5.0.0"
             }
         },
+        "node_modules/styled-components": {
+            "version": "6.1.11",
+            "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.11.tgz",
+            "integrity": "sha512-Ui0jXPzbp1phYij90h12ksljKGqF8ncGx+pjrNPsSPhbUUjWT2tD1FwGo2LF6USCnbrsIhNngDfodhxbegfEOA==",
+            "dependencies": {
+                "@emotion/is-prop-valid": "1.2.2",
+                "@emotion/unitless": "0.8.1",
+                "@types/stylis": "4.2.5",
+                "css-to-react-native": "3.2.0",
+                "csstype": "3.1.3",
+                "postcss": "8.4.38",
+                "shallowequal": "1.1.0",
+                "stylis": "4.3.2",
+                "tslib": "2.6.2"
+            },
+            "engines": {
+                "node": ">= 16"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/styled-components"
+            },
+            "peerDependencies": {
+                "react": ">= 16.8.0",
+                "react-dom": ">= 16.8.0"
+            }
+        },
+        "node_modules/styled-components/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/stylis": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.2.tgz",
+            "integrity": "sha512-bhtUjWd/z6ltJiQwg0dUfxEJ+W+jdqQd8TbWLWyeIJHlnsqmGLRFFd8e5mA0AZi/zx90smXRlN66YMTcaSFifg=="
+        },
         "node_modules/supercluster": {
             "version": "7.1.5",
             "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.1.5.tgz",
@@ -16937,6 +17496,11 @@
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
             "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
             "dev": true
+        },
+        "node_modules/three": {
+            "version": "0.144.0",
+            "resolved": "https://registry.npmjs.org/three/-/three-0.144.0.tgz",
+            "integrity": "sha512-R8AXPuqfjfRJKkYoTQcTK7A6i3AdO9++2n8ubya/GTU+fEHhYKu1ZooRSCPkx69jbnzT7dD/xEo6eROQTt2lJw=="
         },
         "node_modules/through2": {
             "version": "0.6.5",
@@ -17363,6 +17927,14 @@
                 "gl-vec3": "^1.0.2"
             }
         },
+        "node_modules/tweakpane": {
+            "version": "3.1.10",
+            "resolved": "https://registry.npmjs.org/tweakpane/-/tweakpane-3.1.10.tgz",
+            "integrity": "sha512-rqwnl/pUa7+inhI2E9ayGTqqP0EPOOn/wVvSWjZsRbZUItzNShny7pzwL3hVlaN4m9t/aZhsP0aFQ9U5VVR2VQ==",
+            "funding": {
+                "url": "https://github.com/sponsors/cocopon"
+            }
+        },
         "node_modules/tweetnacl": {
             "version": "0.14.5",
             "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
@@ -17637,6 +18209,17 @@
             "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
             "integrity": "sha512-vRCqFv6UhXpWxZPyGDh/F3ZpNv8/qo7w6iufLpQg9aKnQ71qM4B5KiI7Mia9COcjEhrO9LueHpMYjYzsWH3OIg=="
         },
+        "node_modules/unzipit": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/unzipit/-/unzipit-1.4.3.tgz",
+            "integrity": "sha512-gsq2PdJIWWGhx5kcdWStvNWit9FVdTewm4SEG7gFskWs+XCVaULt9+BwuoBtJiRE8eo3L1IPAOrbByNLtLtIlg==",
+            "dependencies": {
+                "uzip-module": "^1.0.2"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/update-browserslist-db": {
             "version": "1.0.13",
             "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
@@ -17726,6 +18309,20 @@
                 "url": "https://opencollective.com/webpack"
             }
         },
+        "node_modules/usehooks-ts": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-3.1.0.tgz",
+            "integrity": "sha512-bBIa7yUyPhE1BCc0GmR96VU/15l/9gP1Ch5mYdLcFBaFGQsdmXkvjV0TtOqW1yUd6VjIwDunm+flSciCQXujiw==",
+            "dependencies": {
+                "lodash.debounce": "^4.0.8"
+            },
+            "engines": {
+                "node": ">=16.15.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0  || ^17 || ^18"
+            }
+        },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -17755,6 +18352,11 @@
             "bin": {
                 "uuid": "bin/uuid"
             }
+        },
+        "node_modules/uzip-module": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/uzip-module/-/uzip-module-1.0.3.tgz",
+            "integrity": "sha512-AMqwWZaknLM77G+VPYNZLEruMGWGzyigPK3/Whg99B3S6vGHuqsyl5ZrOv1UUF3paGK1U6PM0cnayioaryg/fA=="
         },
         "node_modules/v8-compile-cache-lib": {
             "version": "3.0.1",
@@ -17869,6 +18471,11 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/weakmap-shim/-/weakmap-shim-1.1.1.tgz",
             "integrity": "sha512-/wNyG+1FpiHhnfQo+TuA/XAUpvOOkKVl0A4qpT+oGcj5SlZCLmM+M1Py/3Sj8sy+YrEauCVITOxCsZKo6sPbQg=="
+        },
+        "node_modules/web-worker": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.3.0.tgz",
+            "integrity": "sha512-BSR9wyRsy/KOValMgd5kMyr3JzpdeoR9KVId8u5GVlTTAtNChlsE4yTxeY7zMdNSyOmoKBv8NH2qeRY9Tg+IaA=="
         },
         "node_modules/webgl-context": {
             "version": "2.2.0",
@@ -18570,6 +19177,11 @@
             "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
             "dev": true
         },
+        "node_modules/xml-utils": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.9.0.tgz",
+            "integrity": "sha512-bE++owdhr9WNSar5MAL04c727SjSHyEtu2+0hTVbHPeJgzauy5bnhfJV3gdKwm4m+ZNjKmjM97WphKwxWqW1IA=="
+        },
         "node_modules/xmlhttprequest": {
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
@@ -18655,6 +19267,16 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/zarrita": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/zarrita/-/zarrita-0.3.2.tgz",
+            "integrity": "sha512-Zx9nS28C2tXZhF1BmQkgQGi0M/Z5JiM/KCMa+fEYtr/MnIzyizR4sKRA/sXjDP1iuylILWTJAWWBJD//0ONXCA==",
+            "dependencies": {
+                "@zarrita/core": "^0.0.3",
+                "@zarrita/indexing": "^0.0.3",
+                "@zarrita/storage": "^0.0.2"
+            }
+        },
         "node_modules/zero-crossings": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/zero-crossings/-/zero-crossings-1.0.1.tgz",
@@ -18662,6 +19284,11 @@
             "dependencies": {
                 "cwise-compiler": "^1.0.0"
             }
+        },
+        "node_modules/zstddec": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.1.0.tgz",
+            "integrity": "sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg=="
         }
     },
     "dependencies": {
@@ -18676,83 +19303,59 @@
             "resolved": "https://registry.npmjs.org/@aics/browsing-context-messaging/-/browsing-context-messaging-1.1.0.tgz",
             "integrity": "sha512-ts+Z8g/xTJaD+g9fAElEJbclk1L0xDsHy6ioq9N5T4j5WPew46WvZ/794Vxnn9N06KyjkCO6zc4JEl7ZZRSa5Q=="
         },
+        "@aics/volume-viewer": {
+            "version": "3.9.0",
+            "resolved": "https://registry.npmjs.org/@aics/volume-viewer/-/volume-viewer-3.9.0.tgz",
+            "integrity": "sha512-+ftd8aArxi/ICMqrkuGf2Cq98bb4heM4tdy6iyN2B+by9adLKqeIfyaNGcW/WlePeCD9oxV+rdICvlKnNBLM4w==",
+            "requires": {
+                "geotiff": "^2.0.5",
+                "serialize-error": "^11.0.3",
+                "three": "^0.144.0",
+                "tweakpane": "^3.1.9",
+                "zarrita": "^0.3.2"
+            }
+        },
         "@aics/web-3d-viewer": {
-            "version": "file:../website-3d-cell-viewer",
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/@aics/web-3d-viewer/-/web-3d-viewer-2.9.0.tgz",
+            "integrity": "sha512-grGrc8v1cvBmSpGp/s2tqjpkUMrdNLoHu+zXch0A9SFJZQSXDj6cKvrxG0PEqt6CJK8e/Cvturv6GuzGkT+Rig==",
             "requires": {
                 "@aics/volume-viewer": "^3.9.0",
                 "@ant-design/icons": "^5.2.5",
-                "@babel/cli": "^7.14.5",
-                "@babel/core": "^7.14.6",
-                "@babel/preset-env": "^7.23.3",
-                "@babel/preset-react": "^7.14.5",
-                "@babel/preset-typescript": "^7.14.5",
-                "@babel/runtime": "^7.14.6",
-                "@dr.pogodin/babel-preset-svgr": "^1.8.0",
                 "@fortawesome/fontawesome-svg-core": "^6.5.2",
                 "@fortawesome/free-solid-svg-icons": "^6.5.2",
                 "@fortawesome/react-fontawesome": "^0.2.0",
-                "@types/color-string": "^1.5.2",
-                "@types/d3": "^4.13.12",
-                "@types/jest": "^27.4.0",
-                "@types/lodash": "^4.14.185",
-                "@types/react": "^16.x",
-                "@types/react-color": "^3.0.6",
-                "@types/react-dom": "^16.x",
-                "@typescript-eslint/eslint-plugin": "^5.31.0",
-                "@typescript-eslint/parser": "^5.31.0",
-                "antd": "^5.16.2",
-                "axios": "^0.21.1",
-                "babel-loader": "^8.2.2",
-                "babel-plugin-replace-import-extension": "^1.1.3",
-                "clean-webpack-plugin": "^4.0.0-alpha.0",
                 "color-string": "^1.5.3",
-                "command-line-args": "^5.1.1",
-                "copy-webpack-plugin": "^11.0.0",
-                "cross-env": "^7.0.3",
-                "css-loader": "^6.2.0",
                 "d3": "^4.11.0",
-                "esbuild": "^0.14.50",
-                "esbuild-jest": "^0.5.0",
-                "eslint": "^8.20.0",
-                "eslint-plugin-react": "^7.30.1",
-                "file-loader": "^6.2.0",
-                "firebase": "^7.15.3",
                 "fuse.js": "^7.0.0",
-                "gh-pages": "^4.0.0",
-                "html-webpack-plugin": "^5.3.2",
-                "jest": "^27.0.6",
                 "lodash": "^4.17.20",
-                "mini-css-extract-plugin": "^2.2.0",
-                "morgan": "^1.9.1",
                 "nouislider-react": "^3.4.0",
-                "npm-run-all": "^4.1.5",
-                "postcss": "^8.4.31",
-                "postcss-cli": "^8.3.1",
-                "postcss-discard-comments": "^5.0.1",
-                "postcss-extend-rule": "^3.0.0",
-                "postcss-import": "^14.0.2",
-                "postcss-loader": "^6.1.1",
-                "postcss-mixins": "^8.1.0",
-                "postcss-nested": "^5.0.6",
-                "postcss-simple-vars": "^6.0.3",
-                "postcss-url": "^10.1.3",
-                "prop-types": "^15.5.10",
-                "react": "^16.12.0",
                 "react-color": "^2.19.3",
-                "react-dom": "^16.12.0",
                 "react-router-dom": "^6.22.3",
-                "resolve-url-loader": "^5.0.0",
-                "style-loader": "^3.2.1",
                 "styled-components": "^6.1.8",
-                "ts-jest": "^27.1.2",
-                "typescript": "^4.3.5",
-                "url-loader": "^4.1.1",
-                "usehooks-ts": "^3.1.0",
-                "webpack": "^5.89.0",
-                "webpack-cli": "^4.7.2",
-                "webpack-dev-server": "^4.9.3",
-                "webpack-merge": "^5.8.0",
-                "webpack-shell-plugin": "^0.5.0"
+                "usehooks-ts": "^3.1.0"
+            },
+            "dependencies": {
+                "@ant-design/colors": {
+                    "version": "7.0.2",
+                    "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-7.0.2.tgz",
+                    "integrity": "sha512-7KJkhTiPiLHSu+LmMJnehfJ6242OCxSlR3xHVBecYxnMW8MS/878NXct1GqYARyL59fyeFdKRxXTfvR9SnDgJg==",
+                    "requires": {
+                        "@ctrl/tinycolor": "^3.6.1"
+                    }
+                },
+                "@ant-design/icons": {
+                    "version": "5.3.7",
+                    "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-5.3.7.tgz",
+                    "integrity": "sha512-bCPXTAg66f5bdccM4TT21SQBDO1Ek2gho9h3nO9DAKXJP4sq+5VBjrQMSxMVXSB3HyEz+cUbHQ5+6ogxCOpaew==",
+                    "requires": {
+                        "@ant-design/colors": "^7.0.0",
+                        "@ant-design/icons-svg": "^4.4.0",
+                        "@babel/runtime": "^7.11.2",
+                        "classnames": "^2.2.6",
+                        "rc-util": "^5.31.1"
+                    }
+                }
             }
         },
         "@ampproject/remapping": {
@@ -18801,9 +19404,9 @@
             }
         },
         "@ant-design/icons-svg": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/@ant-design/icons-svg/-/icons-svg-4.3.1.tgz",
-            "integrity": "sha512-4QBZg8ccyC6LPIRii7A0bZUk3+lEDCLnhB+FVsflGdcWPPmV+j3fire4AwwoqHV/BibgvBmR9ZIo4s867smv+g=="
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/@ant-design/icons-svg/-/icons-svg-4.4.2.tgz",
+            "integrity": "sha512-vHbT+zJEVzllwP+CM+ul7reTEfBR0vgxFe7+lREAsAA7YGsYpboiq2sQNeQeRvh09GfQgs/GyFEvZpJ9cLXpXA=="
         },
         "@babel/code-frame": {
             "version": "7.23.5",
@@ -20111,6 +20714,24 @@
             "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
             "dev": true
         },
+        "@emotion/is-prop-valid": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz",
+            "integrity": "sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==",
+            "requires": {
+                "@emotion/memoize": "^0.8.1"
+            }
+        },
+        "@emotion/memoize": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
+            "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
+        },
+        "@emotion/unitless": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
+            "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ=="
+        },
         "@eslint-community/eslint-utils": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -20412,6 +21033,35 @@
             "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.4.0.tgz",
             "integrity": "sha512-8cUA/mg0S+BxIZ72TdZRsXKBP5n5uRcE3k29TZhZw6oIiHBt9JA7CTb/4pE1uKtE/q5NeTY2tBDcagoZ+1zjXQ=="
         },
+        "@fortawesome/fontawesome-common-types": {
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.5.2.tgz",
+            "integrity": "sha512-gBxPg3aVO6J0kpfHNILc+NMhXnqHumFxOmjYCFfOiLZfwhnnfhtsdA2hfJlDnj+8PjAs6kKQPenOTKj3Rf7zHw=="
+        },
+        "@fortawesome/fontawesome-svg-core": {
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.5.2.tgz",
+            "integrity": "sha512-5CdaCBGl8Rh9ohNdxeeTMxIj8oc3KNBgIeLMvJosBMdslK/UnEB8rzyDRrbKdL1kDweqBPo4GT9wvnakHWucZw==",
+            "requires": {
+                "@fortawesome/fontawesome-common-types": "6.5.2"
+            }
+        },
+        "@fortawesome/free-solid-svg-icons": {
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.5.2.tgz",
+            "integrity": "sha512-QWFZYXFE7O1Gr1dTIp+D6UcFUF0qElOnZptpi7PBUMylJh+vFmIedVe1Ir6RM1t2tEQLLSV1k7bR4o92M+uqlw==",
+            "requires": {
+                "@fortawesome/fontawesome-common-types": "6.5.2"
+            }
+        },
+        "@fortawesome/react-fontawesome": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.2.tgz",
+            "integrity": "sha512-EnkrprPNqI6SXJl//m29hpaNzOp1bruISWaOiRtkMi/xSvHJlzc2j2JAYS7egxt/EbjSNV/k6Xy0AQI6vB2+1g==",
+            "requires": {
+                "prop-types": "^15.8.1"
+            }
+        },
         "@grpc/grpc-js": {
             "version": "1.9.13",
             "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.13.tgz",
@@ -20489,6 +21139,12 @@
             "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
             "integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
             "dev": true
+        },
+        "@icons/material": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
+            "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==",
+            "requires": {}
         },
         "@jridgewell/gen-mapping": {
             "version": "0.3.3",
@@ -20631,6 +21287,11 @@
                 "fastq": "^1.6.0"
             }
         },
+        "@petamoriken/float16": {
+            "version": "3.8.7",
+            "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.8.7.tgz",
+            "integrity": "sha512-/Ri4xDDpe12NT6Ex/DRgHzLlobiQXEW/hmG08w1wj/YU7hLemk97c+zHQFp0iZQ9r7YqgLEXZR2sls4HxBf9NA=="
+        },
         "@plotly/d3-sankey": {
             "version": "0.7.2",
             "resolved": "https://registry.npmjs.org/@plotly/d3-sankey/-/d3-sankey-0.7.2.tgz",
@@ -20728,6 +21389,11 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
             "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+        },
+        "@remix-run/router": {
+            "version": "1.16.1",
+            "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.16.1.tgz",
+            "integrity": "sha512-es2g3dq6Nb07iFxGk5GuHN20RwBZOsuDQN7izWIisUcv9r+d2C5jQxqmgkdebXgReWfiyUabcki6Fg77mSNrig=="
         },
         "@sinonjs/commons": {
             "version": "1.8.6",
@@ -21254,6 +21920,11 @@
                 "@types/node": "*"
             }
         },
+        "@types/stylis": {
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.5.tgz",
+            "integrity": "sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw=="
+        },
         "@types/tough-cookie": {
             "version": "4.0.5",
             "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
@@ -21632,6 +22303,40 @@
             "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
             "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
             "dev": true
+        },
+        "@zarrita/core": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/@zarrita/core/-/core-0.0.3.tgz",
+            "integrity": "sha512-fWv51b+xbYnws1pkNDPwJQoDa76aojxplHyMup82u11UAiet3gURMsrrkhM6YbeTgSY1A8oGxDOrvar3SiZpLA==",
+            "requires": {
+                "@zarrita/storage": "^0.0.2",
+                "@zarrita/typedarray": "^0.0.1",
+                "numcodecs": "^0.2.2"
+            }
+        },
+        "@zarrita/indexing": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/@zarrita/indexing/-/indexing-0.0.3.tgz",
+            "integrity": "sha512-Q61d9MYX6dsK1DLltEpwx4mJWCZHj0TXiaEN4QpxNDtToa/EoyytP/pYHPypO4GXBscZooJ6eZkKT5FMx9PVfg==",
+            "requires": {
+                "@zarrita/core": "^0.0.3",
+                "@zarrita/storage": "^0.0.2",
+                "@zarrita/typedarray": "^0.0.1"
+            }
+        },
+        "@zarrita/storage": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/@zarrita/storage/-/storage-0.0.2.tgz",
+            "integrity": "sha512-uFt4abAoiOYLroalNDAnVaQxA17zGKrQ0waYKmTVm+bNonz8ggKZP+0FqMhgUZITGChqoANHuYTazbuU5AFXWA==",
+            "requires": {
+                "reference-spec-reader": "^0.2.0",
+                "unzipit": "^1.3.6"
+            }
+        },
+        "@zarrita/typedarray": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/@zarrita/typedarray/-/typedarray-0.0.1.tgz",
+            "integrity": "sha512-ZdvNjYP1bEuQXoSTVkemV99w42jHYrJ3nh9golCLd4MVBlrVbfZo4wWgBslU4JZUaDikhFSH+GWMDgAq/rI32g=="
         },
         "3d-view": {
             "version": "2.0.1",
@@ -22530,6 +23235,11 @@
                 }
             }
         },
+        "camelize": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+            "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ=="
+        },
         "caniuse-lite": {
             "version": "1.0.30001570",
             "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001570.tgz",
@@ -22831,6 +23541,15 @@
             "requires": {
                 "hsluv": "^0.0.3",
                 "mumath": "^3.3.4"
+            }
+        },
+        "color-string": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+            "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+            "requires": {
+                "color-name": "^1.0.0",
+                "simple-swizzle": "^0.2.2"
             }
         },
         "colorette": {
@@ -23151,6 +23870,11 @@
                 }
             }
         },
+        "css-color-keywords": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+            "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg=="
+        },
         "css-font": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/css-font/-/css-font-1.2.0.tgz",
@@ -23324,6 +24048,16 @@
             "resolved": "https://registry.npmjs.org/css-system-font-keywords/-/css-system-font-keywords-1.0.0.tgz",
             "integrity": "sha512-1umTtVd/fXS25ftfjB71eASCrYhilmEsvDEI6wG/QplnmlfmVM5HkZ/ZX46DT5K3eblFPgLUHt5BRCb0YXkSFA=="
         },
+        "css-to-react-native": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+            "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+            "requires": {
+                "camelize": "^1.0.0",
+                "css-color-keywords": "^1.0.0",
+                "postcss-value-parser": "^4.0.2"
+            }
+        },
         "css-what": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
@@ -23389,10 +24123,73 @@
                 "type": "^1.0.1"
             }
         },
+        "d3": {
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/d3/-/d3-4.13.0.tgz",
+            "integrity": "sha512-l8c4+0SldjVKLaE2WG++EQlqD7mh/dmQjvi2L2lKPadAVC+TbJC4ci7Uk9bRi+To0+ansgsS0iWfPjD7DBy+FQ==",
+            "requires": {
+                "d3-array": "1.2.1",
+                "d3-axis": "1.0.8",
+                "d3-brush": "1.0.4",
+                "d3-chord": "1.0.4",
+                "d3-collection": "1.0.4",
+                "d3-color": "1.0.3",
+                "d3-dispatch": "1.0.3",
+                "d3-drag": "1.2.1",
+                "d3-dsv": "1.0.8",
+                "d3-ease": "1.0.3",
+                "d3-force": "1.1.0",
+                "d3-format": "1.2.2",
+                "d3-geo": "1.9.1",
+                "d3-hierarchy": "1.1.5",
+                "d3-interpolate": "1.1.6",
+                "d3-path": "1.0.5",
+                "d3-polygon": "1.0.3",
+                "d3-quadtree": "1.0.3",
+                "d3-queue": "3.0.7",
+                "d3-random": "1.1.0",
+                "d3-request": "1.0.6",
+                "d3-scale": "1.0.7",
+                "d3-selection": "1.3.0",
+                "d3-shape": "1.2.0",
+                "d3-time": "1.0.8",
+                "d3-time-format": "2.1.1",
+                "d3-timer": "1.0.7",
+                "d3-transition": "1.1.1",
+                "d3-voronoi": "1.1.2",
+                "d3-zoom": "1.7.1"
+            }
+        },
         "d3-array": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.1.tgz",
             "integrity": "sha512-CyINJQ0SOUHojDdFDH4JEM0552vCR1utGyLHegJHyYH0JyCpSeTPxi4OBqHMA2jJZq4NH782LtaJWBImqI/HBw=="
+        },
+        "d3-axis": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-1.0.8.tgz",
+            "integrity": "sha512-K0djTb26iQ6AsuD2d6Ka08wBHf4V30awIxV4XFuB/iLzYtTqqJlE/nIN0DBJJCX7lbOqbt2/oeX3r+sU5k2veg=="
+        },
+        "d3-brush": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-1.0.4.tgz",
+            "integrity": "sha512-nUFueDzOlvwFvuOBynGSyJM7Wt1H9fKgJeoWFSg3ScS4c7FJBch92FKUJKum4xtgPYHdgH2C3bRg3GzSVltCJQ==",
+            "requires": {
+                "d3-dispatch": "1",
+                "d3-drag": "1",
+                "d3-interpolate": "1",
+                "d3-selection": "1",
+                "d3-transition": "1"
+            }
+        },
+        "d3-chord": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-1.0.4.tgz",
+            "integrity": "sha512-o0ExexkK1N0KikUakKrQwttP5Flu8AYD6iBUh3AdPJqnTh6xlvcX5wFRuuo29sLOAr9+T4yZPUH1S3CCQJ1SlQ==",
+            "requires": {
+                "d3-array": "1",
+                "d3-path": "1"
+            }
         },
         "d3-collection": {
             "version": "1.0.4",
@@ -23409,15 +24206,121 @@
             "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.3.tgz",
             "integrity": "sha512-Qh2DR3neW3lq/ug4oymXHYoIsA91nYt47ERb+fPKjRg6zLij06aP7KqHHl2NyziK9ASxrR3GLkHCtZvXe/jMVg=="
         },
+        "d3-drag": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-1.2.1.tgz",
+            "integrity": "sha512-Cg8/K2rTtzxzrb0fmnYOUeZHvwa4PHzwXOLZZPwtEs2SKLLKLXeYwZKBB+DlOxUvFmarOnmt//cU4+3US2lyyQ==",
+            "requires": {
+                "d3-dispatch": "1",
+                "d3-selection": "1"
+            }
+        },
+        "d3-dsv": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-1.0.8.tgz",
+            "integrity": "sha512-IVCJpQ+YGe3qu6odkPQI0KPqfxkhbP/oM1XhhE/DFiYmcXKfCRub4KXyiuehV1d4drjWVXHUWx4gHqhdZb6n/A==",
+            "requires": {
+                "commander": "2",
+                "iconv-lite": "0.4",
+                "rw": "1"
+            }
+        },
+        "d3-ease": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.3.tgz",
+            "integrity": "sha512-io3QwOJwVPAxRF2UXpKpCdz2wm/7VLFCQQ1yy+GzX6YCtt3vi2BGnimI8agSF5jyUrHsADyF303d2S+ps7zU8w=="
+        },
+        "d3-force": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.1.0.tgz",
+            "integrity": "sha512-2HVQz3/VCQs0QeRNZTYb7GxoUCeb6bOzMp/cGcLa87awY9ZsPvXOGeZm0iaGBjXic6I1ysKwMn+g+5jSAdzwcg==",
+            "requires": {
+                "d3-collection": "1",
+                "d3-dispatch": "1",
+                "d3-quadtree": "1",
+                "d3-timer": "1"
+            }
+        },
+        "d3-format": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.2.2.tgz",
+            "integrity": "sha512-zH9CfF/3C8zUI47nsiKfD0+AGDEuM8LwBIP7pBVpyR4l/sKkZqITmMtxRp04rwBrlshIZ17XeFAaovN3++wzkw=="
+        },
+        "d3-geo": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.9.1.tgz",
+            "integrity": "sha512-l9wL/cEQkyZQYXw3xbmLsH3eQ5ij+icNfo4r0GrLa5rOCZR/e/3am45IQ0FvQ5uMsv+77zBRunLc9ufTWSQYFA==",
+            "requires": {
+                "d3-array": "1"
+            }
+        },
+        "d3-hierarchy": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-1.1.5.tgz",
+            "integrity": "sha512-PcsLIhThc60mWnxlojIOH7Sc0tQ2DgLWfEwEAyzCtej5f3H9wSsRmrg5pEhKZLrwiJnI2zyw/pznJxL9a/Eugw=="
+        },
+        "d3-interpolate": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.1.6.tgz",
+            "integrity": "sha512-mOnv5a+pZzkNIHtw/V6I+w9Lqm9L5bG3OTXPM5A+QO0yyVMQ4W1uZhR+VOJmazaOZXri2ppbiZ5BUNWT0pFM9A==",
+            "requires": {
+                "d3-color": "1"
+            }
+        },
         "d3-path": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.5.tgz",
             "integrity": "sha512-eD76prgnTKYkLzHlY2UMyOEZXTpC+WOanCr1BLxo38w4fPPPq/LgCFqRQvqFU3AJngfZmmKR7rgKPZ4EGJ9Atw=="
         },
+        "d3-polygon": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-1.0.3.tgz",
+            "integrity": "sha512-2zP7GOvf4XOWTeQouK7fCO534yQxyhYYTw6GTqcXifIalHgA6qV/es+4GRQii9m6XxEPFcht4loobD/o2iEo1A=="
+        },
         "d3-quadtree": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-1.0.3.tgz",
             "integrity": "sha512-U2Jc3jF3JOBGXIOnvWY9C4ekRwRX9hEVpMMmeduJyaxAwPmoe7t84iZFTLn1RwYOyrXxJF55H/Hrg186TFQQdw=="
+        },
+        "d3-queue": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/d3-queue/-/d3-queue-3.0.7.tgz",
+            "integrity": "sha512-2rs+6pNFKkrJhqe1rg5znw7dKJ7KZr62j9aLZfhondkrnz6U7VRmJj1UGcbD8MRc46c7H8m4SWhab8EalBQrkw=="
+        },
+        "d3-random": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-1.1.0.tgz",
+            "integrity": "sha512-XuMbjx3Jq4EWfJP4g6nR7zns/bZfaVbWHWfR8auDkEiWCzVbWifmasfszV1ZRN3xXK3nY4RUFL2nTIhceGZSFQ=="
+        },
+        "d3-request": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/d3-request/-/d3-request-1.0.6.tgz",
+            "integrity": "sha512-FJj8ySY6GYuAJHZMaCQ83xEYE4KbkPkmxZ3Hu6zA1xxG2GD+z6P+Lyp+zjdsHf0xEbp2xcluDI50rCS855EQ6w==",
+            "requires": {
+                "d3-collection": "1",
+                "d3-dispatch": "1",
+                "d3-dsv": "1",
+                "xmlhttprequest": "1"
+            }
+        },
+        "d3-scale": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+            "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+            "requires": {
+                "d3-array": "^1.2.0",
+                "d3-collection": "1",
+                "d3-color": "1",
+                "d3-format": "1",
+                "d3-interpolate": "1",
+                "d3-time": "1",
+                "d3-time-format": "2"
+            }
+        },
+        "d3-selection": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.3.0.tgz",
+            "integrity": "sha512-qgpUOg9tl5CirdqESUAu0t9MU/t3O9klYfGfyKsXEmhyxyzLpzpeh08gaxBUTQw1uXIOkr/30Ut2YRjSSxlmHA=="
         },
         "d3-shape": {
             "version": "1.2.0",
@@ -23432,10 +24335,48 @@
             "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.0.8.tgz",
             "integrity": "sha512-YRZkNhphZh3KcnBfitvF3c6E0JOFGikHZ4YqD+Lzv83ZHn1/u6yGenRU1m+KAk9J1GnZMnKcrtfvSktlA1DXNQ=="
         },
+        "d3-time-format": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.1.1.tgz",
+            "integrity": "sha512-8kAkymq2WMfzW7e+s/IUNAtN/y3gZXGRrdGfo6R8NKPAA85UBTxZg5E61bR6nLwjPjj4d3zywSQe1CkYLPFyrw==",
+            "requires": {
+                "d3-time": "1"
+            }
+        },
         "d3-timer": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.7.tgz",
             "integrity": "sha512-vMZXR88XujmG/L5oB96NNKH5lCWwiLM/S2HyyAQLcjWJCloK5shxta4CwOFYLZoY3AWX73v8Lgv4cCAdWtRmOA=="
+        },
+        "d3-transition": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-1.1.1.tgz",
+            "integrity": "sha512-xeg8oggyQ+y5eb4J13iDgKIjUcEfIOZs2BqV/eEmXm2twx80wTzJ4tB4vaZ5BKfz7XsI/DFmQL5me6O27/5ykQ==",
+            "requires": {
+                "d3-color": "1",
+                "d3-dispatch": "1",
+                "d3-ease": "1",
+                "d3-interpolate": "1",
+                "d3-selection": "^1.1.0",
+                "d3-timer": "1"
+            }
+        },
+        "d3-voronoi": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.2.tgz",
+            "integrity": "sha512-RhGS1u2vavcO7ay7ZNAPo4xeDh/VYeGof3x5ZLJBQgYhLegxr3s5IykvWmJ94FTU6mcbtp4sloqZ54mP6R4Utw=="
+        },
+        "d3-zoom": {
+            "version": "1.7.1",
+            "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-1.7.1.tgz",
+            "integrity": "sha512-sZHQ55DGq5BZBFGnRshUT8tm2sfhPHFnOlmPbbwTkAoPeVdRTkB4Xsf9GCY0TSHrTD8PeJPZGmP/TpGicwJDJQ==",
+            "requires": {
+                "d3-dispatch": "1",
+                "d3-drag": "1",
+                "d3-interpolate": "1",
+                "d3-selection": "1",
+                "d3-transition": "1"
+            }
         },
         "dashdash": {
             "version": "1.14.1",
@@ -25154,6 +26095,11 @@
             "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
             "dev": true
         },
+        "fuse.js": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.0.0.tgz",
+            "integrity": "sha512-14F4hBIxqKvD4Zz/XjDc3y94mNZN6pRv3U13Udo0lNLCWRBUsrMv2xwcF/y/Z5sV6+FQW+/ow68cHpm4sunt8Q=="
+        },
         "gamma": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/gamma/-/gamma-0.1.0.tgz",
@@ -25169,6 +26115,21 @@
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.1.tgz",
             "integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg=="
+        },
+        "geotiff": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.1.3.tgz",
+            "integrity": "sha512-PT6uoF5a1+kbC3tHmZSUsLHBp2QJlHasxxxxPW47QIY1VBKpFB+FcDvX+MxER6UzgLQZ0xDzJ9s48B9JbOCTqA==",
+            "requires": {
+                "@petamoriken/float16": "^3.4.7",
+                "lerc": "^3.0.0",
+                "pako": "^2.0.4",
+                "parse-headers": "^2.0.2",
+                "quick-lru": "^6.1.1",
+                "web-worker": "^1.2.0",
+                "xml-utils": "^1.0.2",
+                "zstddec": "^0.1.0"
+            }
         },
         "get-caller-file": {
             "version": "2.0.5",
@@ -26232,7 +27193,6 @@
             "version": "0.4.24",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
             "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-            "dev": true,
             "requires": {
                 "safer-buffer": ">= 2.1.2 < 3"
             }
@@ -27024,6 +27984,11 @@
             "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
             "dev": true
         },
+        "lerc": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
+            "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww=="
+        },
         "lerp": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/lerp/-/lerp-1.0.3.tgz",
@@ -27149,8 +28114,7 @@
         "lodash-es": {
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-            "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-            "dev": true
+            "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
         },
         "lodash.camelcase": {
             "version": "4.3.0",
@@ -27363,6 +28327,11 @@
             "requires": {
                 "gl-mat4": "^1.0.1"
             }
+        },
+        "material-colors": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
+            "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
         },
         "math-log2": {
             "version": "1.0.1",
@@ -27733,8 +28702,7 @@
         "nanoid": {
             "version": "3.3.7",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-            "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
-            "dev": true
+            "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g=="
         },
         "natural-compare": {
             "version": "1.4.0",
@@ -27965,6 +28933,19 @@
             "resolved": "https://registry.npmjs.org/normals/-/normals-1.1.0.tgz",
             "integrity": "sha512-XWeliW48BLvbVJ+cjQAOE+tA0m1M7Yi1iTPphAS9tBmW1A/c/cOVnEUecPCCMH5lEAihAcG6IRle56ls9k3xug=="
         },
+        "nouislider": {
+            "version": "14.7.0",
+            "resolved": "https://registry.npmjs.org/nouislider/-/nouislider-14.7.0.tgz",
+            "integrity": "sha512-4RtQ1+LHJKesDCNJrXkQcwXAWCrC2aggdLYMstS/G5fEWL+fXZbUA9pwVNHFghMGuFGRATlDLNInRaPeRKzpFQ=="
+        },
+        "nouislider-react": {
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/nouislider-react/-/nouislider-react-3.4.2.tgz",
+            "integrity": "sha512-7YsyHY/j7yxaoNzt4PGZMoJLdh/e8aY5rYZ5xxpBv9LAs/gqt+M/Lk9SAi05+XF4mI749B2ISZjHdEIZUMWY6g==",
+            "requires": {
+                "nouislider": "^14.6.3"
+            }
+        },
         "npm-run-path": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -27996,6 +28977,11 @@
             "requires": {
                 "is-finite": "^1.0.1"
             }
+        },
+        "numcodecs": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/numcodecs/-/numcodecs-0.2.2.tgz",
+            "integrity": "sha512-Y5K8mv80yb4MgVpcElBkUeMZqeE4TrovxRit/dTZvoRl6YkB6WEjY+fiUjGCblITnt3T3fmrDg8yRWu0gOLjhQ=="
         },
         "numeric": {
             "version": "1.2.6",
@@ -28229,6 +29215,11 @@
                 "repeat-string": "^1.3.0"
             }
         },
+        "pako": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+            "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
+        },
         "param-case": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
@@ -28260,6 +29251,11 @@
             "version": "3.1.8",
             "resolved": "https://registry.npmjs.org/parenthesis/-/parenthesis-3.1.8.tgz",
             "integrity": "sha512-KF/U8tk54BgQewkJPvB4s/US3VQY68BRDpH638+7O/n58TpnwiwnOtGIOsT2/i+M78s61BBpeC83STB88d8sqw=="
+        },
+        "parse-headers": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.5.tgz",
+            "integrity": "sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA=="
         },
         "parse-json": {
             "version": "5.2.0",
@@ -28445,8 +29441,7 @@
         "picocolors": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-            "dev": true
+            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
         },
         "picomatch": {
             "version": "2.3.1",
@@ -28696,14 +29691,13 @@
             }
         },
         "postcss": {
-            "version": "8.4.32",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz",
-            "integrity": "sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==",
-            "dev": true,
+            "version": "8.4.38",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
+            "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
             "requires": {
                 "nanoid": "^3.3.7",
                 "picocolors": "^1.0.0",
-                "source-map-js": "^1.0.2"
+                "source-map-js": "^1.2.0"
             }
         },
         "postcss-attribute-case-insensitive": {
@@ -29744,8 +30738,7 @@
         "postcss-value-parser": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-            "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-            "dev": true
+            "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
         },
         "postcss-values-parser": {
             "version": "2.0.1",
@@ -29905,6 +30898,11 @@
             "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
             "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
             "dev": true
+        },
+        "quick-lru": {
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.2.tgz",
+            "integrity": "sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ=="
         },
         "quickselect": {
             "version": "2.0.0",
@@ -30738,6 +31736,20 @@
                 "prop-types": "^15.6.2"
             }
         },
+        "react-color": {
+            "version": "2.19.3",
+            "resolved": "https://registry.npmjs.org/react-color/-/react-color-2.19.3.tgz",
+            "integrity": "sha512-LEeGE/ZzNLIsFWa1TMe8y5VYqr7bibneWmvJwm1pCn/eNmrabWDh659JSPn9BuaMpEfU83WTOJfnCcjDZwNQTA==",
+            "requires": {
+                "@icons/material": "^0.2.4",
+                "lodash": "^4.17.15",
+                "lodash-es": "^4.17.15",
+                "material-colors": "^1.2.1",
+                "prop-types": "^15.5.10",
+                "reactcss": "^1.2.0",
+                "tinycolor2": "^1.4.1"
+            }
+        },
         "react-dom": {
             "version": "16.14.0",
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
@@ -30792,6 +31804,23 @@
                 "react-lifecycles-compat": "^3.0.0"
             }
         },
+        "react-router": {
+            "version": "6.23.1",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.23.1.tgz",
+            "integrity": "sha512-fzcOaRF69uvqbbM7OhvQyBTFDVrrGlsFdS3AL+1KfIBtGETibHzi3FkoTRyiDJnWNc2VxrfvR+657ROHjaNjqQ==",
+            "requires": {
+                "@remix-run/router": "1.16.1"
+            }
+        },
+        "react-router-dom": {
+            "version": "6.23.1",
+            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.23.1.tgz",
+            "integrity": "sha512-utP+K+aSTtEdbWpC+4gxhdlPFwuEfDKq8ZrPFU65bbRJY+l706qjR7yaidBpo3MSeA/fzwbXWbKBI6ftOnP3OQ==",
+            "requires": {
+                "@remix-run/router": "1.16.1",
+                "react-router": "6.23.1"
+            }
+        },
         "react-slick": {
             "version": "0.25.2",
             "resolved": "https://registry.npmjs.org/react-slick/-/react-slick-0.25.2.tgz",
@@ -30802,6 +31831,14 @@
                 "json2mq": "^0.2.0",
                 "lodash.debounce": "^4.0.8",
                 "resize-observer-polyfill": "^1.5.0"
+            }
+        },
+        "reactcss": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
+            "integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
+            "requires": {
+                "lodash": "^4.0.1"
             }
         },
         "readable-stream": {
@@ -30877,6 +31914,11 @@
                 "rxjs": "^5.5.11",
                 "symbol-observable": "^1.2.0"
             }
+        },
+        "reference-spec-reader": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/reference-spec-reader/-/reference-spec-reader-0.2.0.tgz",
+            "integrity": "sha512-q0mfCi5yZSSHXpCyxjgQeaORq3tvDsxDyzaadA/5+AbAUwRyRuuTh0aRQuE/vAOt/qzzxidJ5iDeu1cLHaNBlQ=="
         },
         "reflect.getprototypeof": {
             "version": "1.0.4",
@@ -31564,6 +32606,21 @@
                 }
             }
         },
+        "serialize-error": {
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-11.0.3.tgz",
+            "integrity": "sha512-2G2y++21dhj2R7iHAdd0FIzjGwuKZld+7Pl/bTU6YIkrC2ZMbVUjm+luj6A6V34Rv9XfKJDKpTWu9W4Gse1D9g==",
+            "requires": {
+                "type-fest": "^2.12.2"
+            },
+            "dependencies": {
+                "type-fest": {
+                    "version": "2.19.0",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+                    "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+                }
+            }
+        },
         "serialize-javascript": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
@@ -31752,6 +32809,21 @@
             "resolved": "https://registry.npmjs.org/signum/-/signum-1.0.0.tgz",
             "integrity": "sha512-yodFGwcyt59XRh7w5W3jPcIQb3Bwi21suEfT7MAWnBX3iCdklJpgDgvGT9o04UonglZN5SNMfJFkHIR/jO8GHw=="
         },
+        "simple-swizzle": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+            "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+            "requires": {
+                "is-arrayish": "^0.3.1"
+            },
+            "dependencies": {
+                "is-arrayish": {
+                    "version": "0.3.2",
+                    "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+                    "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+                }
+            }
+        },
         "simplicial-complex": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/simplicial-complex/-/simplicial-complex-1.0.0.tgz",
@@ -31879,10 +32951,9 @@
             "devOptional": true
         },
         "source-map-js": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-            "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-            "dev": true
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+            "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg=="
         },
         "source-map-support": {
             "version": "0.5.21",
@@ -32115,6 +33186,34 @@
             "dev": true,
             "requires": {}
         },
+        "styled-components": {
+            "version": "6.1.11",
+            "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.11.tgz",
+            "integrity": "sha512-Ui0jXPzbp1phYij90h12ksljKGqF8ncGx+pjrNPsSPhbUUjWT2tD1FwGo2LF6USCnbrsIhNngDfodhxbegfEOA==",
+            "requires": {
+                "@emotion/is-prop-valid": "1.2.2",
+                "@emotion/unitless": "0.8.1",
+                "@types/stylis": "4.2.5",
+                "css-to-react-native": "3.2.0",
+                "csstype": "3.1.3",
+                "postcss": "8.4.38",
+                "shallowequal": "1.1.0",
+                "stylis": "4.3.2",
+                "tslib": "2.6.2"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.6.2",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+                    "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+                }
+            }
+        },
+        "stylis": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.2.tgz",
+            "integrity": "sha512-bhtUjWd/z6ltJiQwg0dUfxEJ+W+jdqQd8TbWLWyeIJHlnsqmGLRFFd8e5mA0AZi/zx90smXRlN66YMTcaSFifg=="
+        },
         "supercluster": {
             "version": "7.1.5",
             "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.1.5.tgz",
@@ -32258,6 +33357,11 @@
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
             "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
             "dev": true
+        },
+        "three": {
+            "version": "0.144.0",
+            "resolved": "https://registry.npmjs.org/three/-/three-0.144.0.tgz",
+            "integrity": "sha512-R8AXPuqfjfRJKkYoTQcTK7A6i3AdO9++2n8ubya/GTU+fEHhYKu1ZooRSCPkx69jbnzT7dD/xEo6eROQTt2lJw=="
         },
         "through2": {
             "version": "0.6.5",
@@ -32591,6 +33695,11 @@
                 "gl-vec3": "^1.0.2"
             }
         },
+        "tweakpane": {
+            "version": "3.1.10",
+            "resolved": "https://registry.npmjs.org/tweakpane/-/tweakpane-3.1.10.tgz",
+            "integrity": "sha512-rqwnl/pUa7+inhI2E9ayGTqqP0EPOOn/wVvSWjZsRbZUItzNShny7pzwL3hVlaN4m9t/aZhsP0aFQ9U5VVR2VQ=="
+        },
         "tweetnacl": {
             "version": "0.14.5",
             "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
@@ -32787,6 +33896,14 @@
             "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
             "integrity": "sha512-vRCqFv6UhXpWxZPyGDh/F3ZpNv8/qo7w6iufLpQg9aKnQ71qM4B5KiI7Mia9COcjEhrO9LueHpMYjYzsWH3OIg=="
         },
+        "unzipit": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/unzipit/-/unzipit-1.4.3.tgz",
+            "integrity": "sha512-gsq2PdJIWWGhx5kcdWStvNWit9FVdTewm4SEG7gFskWs+XCVaULt9+BwuoBtJiRE8eo3L1IPAOrbByNLtLtIlg==",
+            "requires": {
+                "uzip-module": "^1.0.2"
+            }
+        },
         "update-browserslist-db": {
             "version": "1.0.13",
             "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
@@ -32835,6 +33952,14 @@
                 }
             }
         },
+        "usehooks-ts": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-3.1.0.tgz",
+            "integrity": "sha512-bBIa7yUyPhE1BCc0GmR96VU/15l/9gP1Ch5mYdLcFBaFGQsdmXkvjV0TtOqW1yUd6VjIwDunm+flSciCQXujiw==",
+            "requires": {
+                "lodash.debounce": "^4.0.8"
+            }
+        },
         "util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -32857,6 +33982,11 @@
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
             "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
             "dev": true
+        },
+        "uzip-module": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/uzip-module/-/uzip-module-1.0.3.tgz",
+            "integrity": "sha512-AMqwWZaknLM77G+VPYNZLEruMGWGzyigPK3/Whg99B3S6vGHuqsyl5ZrOv1UUF3paGK1U6PM0cnayioaryg/fA=="
         },
         "v8-compile-cache-lib": {
             "version": "3.0.1",
@@ -32963,6 +34093,11 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/weakmap-shim/-/weakmap-shim-1.1.1.tgz",
             "integrity": "sha512-/wNyG+1FpiHhnfQo+TuA/XAUpvOOkKVl0A4qpT+oGcj5SlZCLmM+M1Py/3Sj8sy+YrEauCVITOxCsZKo6sPbQg=="
+        },
+        "web-worker": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.3.0.tgz",
+            "integrity": "sha512-BSR9wyRsy/KOValMgd5kMyr3JzpdeoR9KVId8u5GVlTTAtNChlsE4yTxeY7zMdNSyOmoKBv8NH2qeRY9Tg+IaA=="
         },
         "webgl-context": {
             "version": "2.2.0",
@@ -33456,6 +34591,11 @@
             "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
             "dev": true
         },
+        "xml-utils": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.9.0.tgz",
+            "integrity": "sha512-bE++owdhr9WNSar5MAL04c727SjSHyEtu2+0hTVbHPeJgzauy5bnhfJV3gdKwm4m+ZNjKmjM97WphKwxWqW1IA=="
+        },
         "xmlhttprequest": {
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
@@ -33514,6 +34654,16 @@
             "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
             "dev": true
         },
+        "zarrita": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/zarrita/-/zarrita-0.3.2.tgz",
+            "integrity": "sha512-Zx9nS28C2tXZhF1BmQkgQGi0M/Z5JiM/KCMa+fEYtr/MnIzyizR4sKRA/sXjDP1iuylILWTJAWWBJD//0ONXCA==",
+            "requires": {
+                "@zarrita/core": "^0.0.3",
+                "@zarrita/indexing": "^0.0.3",
+                "@zarrita/storage": "^0.0.2"
+            }
+        },
         "zero-crossings": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/zero-crossings/-/zero-crossings-1.0.1.tgz",
@@ -33521,6 +34671,11 @@
             "requires": {
                 "cwise-compiler": "^1.0.0"
             }
+        },
+        "zstddec": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.1.0.tgz",
+            "integrity": "sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg=="
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     },
     "dependencies": {
         "@aics/browsing-context-messaging": "~1.1",
-        "@aics/web-3d-viewer": "^2.7.4",
+        "@aics/web-3d-viewer": "^2.9.0",
         "@ant-design/icons": "^4.2.2",
         "antd": "^3.26.20",
         "axios": "^0.21.1",

--- a/src/components/CellViewer/index.tsx
+++ b/src/components/CellViewer/index.tsx
@@ -22,11 +22,10 @@ const CellViewer: React.FunctionComponent<VolumeViewerProps> = (props) => {
         <div style={CONTAINER_STYLE}>
             <ImageViewerApp
                 cellId={props.cellId}
-                baseUrl={props.baseUrl}
-                cellPath={props.cellPath}
-                fovDownloadHref={props.fovDownloadHref}
-                cellDownloadHref={props.cellDownloadHref}
-                fovPath={props.fovPath}
+                imageUrl={props.baseUrl + props.cellPath}
+                parentImageDownloadHref={props.fovDownloadHref}
+                imageDownloadHref={props.cellDownloadHref}
+                parentImageUrl={props.baseUrl + props.fovPath}
                 viewerChannelSettings={props.viewerChannelSettings}
                 transform={props.transform}
                 onControlPanelToggle={props.onControlPanelToggle}

--- a/src/components/CellViewer/index.tsx
+++ b/src/components/CellViewer/index.tsx
@@ -4,6 +4,8 @@ import React from "react";
 // TODO: Fix viewer so this is unnecessary?
 import "antd/lib/drawer/style/index.less";
 
+import styles from "./style.css";
+
 import { VolumeViewerProps } from "../../containers/Cfe/selectors";
 
 const CONTAINER_STYLE = {
@@ -19,7 +21,7 @@ const CellViewer: React.FunctionComponent<VolumeViewerProps> = (props) => {
     }
 
     return (
-        <div style={CONTAINER_STYLE}>
+        <div className={styles.cellViewerContainer} style={CONTAINER_STYLE}>
             <ImageViewerApp
                 cellId={props.cellId}
                 imageUrl={props.baseUrl + props.cellPath}

--- a/src/components/CellViewer/style.css
+++ b/src/components/CellViewer/style.css
@@ -1,0 +1,22 @@
+/* Style overrides to fix alignment caused by an Ant version + font mismatch.
+ * TODO: Remove this when Ant version is upgraded?
+*/
+
+.cell-viewer-container {
+    & :global(.ant-collapse-header) {
+        align-items: center !important;
+        cursor: auto !important;
+
+        & :global(.ant-collapse-arrow) > span {
+            cursor: pointer !important;
+        }
+
+        & :global(.ant-collapse-extra) {
+            width: 45% !important;
+        }
+    }
+
+    & :global(.channel-visibility-controls) > :global(.ant-btn-icon-only) {
+        border-color: transparent !important;
+    }
+}

--- a/src/components/CellViewer/style.css
+++ b/src/components/CellViewer/style.css
@@ -19,4 +19,9 @@
     & :global(.channel-visibility-controls) > :global(.ant-btn-icon-only) {
         border-color: transparent !important;
     }
+
+    & :global(.ant-drawer.ant-drawer-bottom) {
+        height: 100% !important;
+        position: relative !important;
+    }
 }

--- a/src/components/CellViewer/style.css
+++ b/src/components/CellViewer/style.css
@@ -3,6 +3,9 @@
 */
 
 .cell-viewer-container {
+    /* Align header items; fix a bug where the entire div would show pointer-interactive
+     * when only the icon (span) was clickable.
+    */
     & :global(.ant-collapse-header) {
         align-items: center !important;
         cursor: auto !important;
@@ -16,12 +19,19 @@
         }
     }
 
+    /* Remove outlines on channel settings toggles  */
     & :global(.channel-visibility-controls) > :global(.ant-btn-icon-only) {
         border-color: transparent !important;
     }
 
+    /* Fix missing bottom drawer */
     & :global(.ant-drawer.ant-drawer-bottom) {
         height: 100% !important;
         position: relative !important;
+    }
+
+    /* Fix icons in toolbar not being centered */
+    & :global(.viewer-toolbar-group) > button:global(.ant-btn-icon-only) {
+        padding: 0 !important;
     }
 }

--- a/src/state/test/mocks.ts
+++ b/src/state/test/mocks.ts
@@ -1,4 +1,4 @@
-import { ViewerChannelSettings } from "@aics/web-3d-viewer/type-declarations";
+import { ViewerChannelSettings } from "@aics/web-3d-viewer";
 import {
     CELL_ID_KEY,
     FOV_ID_KEY,

--- a/src/state/test/mocks.ts
+++ b/src/state/test/mocks.ts
@@ -1,4 +1,4 @@
-import { ViewerChannelSettings } from "@aics/web-3d-viewer";
+import type { ViewerChannelSettings } from "@aics/web-3d-viewer";
 import {
     CELL_ID_KEY,
     FOV_ID_KEY,

--- a/src/state/test/mocks.ts
+++ b/src/state/test/mocks.ts
@@ -1,4 +1,4 @@
-import type { ViewerChannelSettings } from "@aics/web-3d-viewer";
+import { ViewerChannelSettings } from "@aics/web-3d-viewer/type-declarations";
 import {
     CELL_ID_KEY,
     FOV_ID_KEY,


### PR DESCRIPTION
Problem
=======
Closes #163, upgrading CFE to use the latest version of website-3d-cell-viewer.

*Estimated review size: small, 10 minutes*

NOTE: This build will be broken until #166 is merged into this branch, due to dependency issues with Ant.

Solution
========
- Updates web-3d-viewer to version 2.9.0.
- Updates the API for the web-3d-viewer.
- Fixes some broken styling caused by Ant version mismatch. (Will be removed in #166.)

## Type of change
* Breaking change (fix or feature that would cause existing functionality to not work as expected)
