### PR TITLE
fix: Full field toggle is no longer visible on datasets without full field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "ISC",
             "dependencies": {
                 "@aics/browsing-context-messaging": "~1.1",
-                "@aics/web-3d-viewer": "^2.9.0",
+                "@aics/web-3d-viewer": "^2.9.2",
                 "@ant-design/icons": "^4.2.2",
                 "antd": "^5.17.4",
                 "axios": "^0.21.1",
@@ -103,9 +103,9 @@
             "integrity": "sha512-ts+Z8g/xTJaD+g9fAElEJbclk1L0xDsHy6ioq9N5T4j5WPew46WvZ/794Vxnn9N06KyjkCO6zc4JEl7ZZRSa5Q=="
         },
         "node_modules/@aics/volume-viewer": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/@aics/volume-viewer/-/volume-viewer-3.9.0.tgz",
-            "integrity": "sha512-+ftd8aArxi/ICMqrkuGf2Cq98bb4heM4tdy6iyN2B+by9adLKqeIfyaNGcW/WlePeCD9oxV+rdICvlKnNBLM4w==",
+            "version": "3.11.1",
+            "resolved": "https://registry.npmjs.org/@aics/volume-viewer/-/volume-viewer-3.11.1.tgz",
+            "integrity": "sha512-aFG9SPHK0ddsqj2jcbKPMWF9UTuCsSg9J3kDXWLbmG7XQRKcnJ0R5KTQ9UegYG6OXdDFEPDI4lTKe5/IhJtgJw==",
             "dependencies": {
                 "geotiff": "^2.0.5",
                 "serialize-error": "^11.0.3",
@@ -115,17 +115,17 @@
             }
         },
         "node_modules/@aics/web-3d-viewer": {
-            "version": "2.9.0",
-            "resolved": "https://registry.npmjs.org/@aics/web-3d-viewer/-/web-3d-viewer-2.9.0.tgz",
-            "integrity": "sha512-grGrc8v1cvBmSpGp/s2tqjpkUMrdNLoHu+zXch0A9SFJZQSXDj6cKvrxG0PEqt6CJK8e/Cvturv6GuzGkT+Rig==",
+            "version": "2.9.2",
+            "resolved": "https://registry.npmjs.org/@aics/web-3d-viewer/-/web-3d-viewer-2.9.2.tgz",
+            "integrity": "sha512-D16TLphuHUMMXbu7xH8WO+kXj4mOkME9nrkIyK0SfRW43anBlv1YWufSh1wgXpr69cnykY83cMkNSX9LwtV6eA==",
             "dependencies": {
-                "@aics/volume-viewer": "^3.9.0",
+                "@aics/volume-viewer": "^3.11.0",
                 "@ant-design/icons": "^5.2.5",
                 "@fortawesome/fontawesome-svg-core": "^6.5.2",
                 "@fortawesome/free-solid-svg-icons": "^6.5.2",
                 "@fortawesome/react-fontawesome": "^0.2.0",
                 "color-string": "^1.5.3",
-                "d3": "^4.11.0",
+                "d3": "^7.9.0",
                 "fuse.js": "^7.0.0",
                 "lodash": "^4.17.20",
                 "nouislider-react": "^3.4.0",
@@ -6279,40 +6279,43 @@
             }
         },
         "node_modules/d3": {
-            "version": "4.13.0",
-            "resolved": "https://registry.npmjs.org/d3/-/d3-4.13.0.tgz",
-            "integrity": "sha512-l8c4+0SldjVKLaE2WG++EQlqD7mh/dmQjvi2L2lKPadAVC+TbJC4ci7Uk9bRi+To0+ansgsS0iWfPjD7DBy+FQ==",
+            "version": "7.9.0",
+            "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+            "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
             "dependencies": {
-                "d3-array": "1.2.1",
-                "d3-axis": "1.0.8",
-                "d3-brush": "1.0.4",
-                "d3-chord": "1.0.4",
-                "d3-collection": "1.0.4",
-                "d3-color": "1.0.3",
-                "d3-dispatch": "1.0.3",
-                "d3-drag": "1.2.1",
-                "d3-dsv": "1.0.8",
-                "d3-ease": "1.0.3",
-                "d3-force": "1.1.0",
-                "d3-format": "1.2.2",
-                "d3-geo": "1.9.1",
-                "d3-hierarchy": "1.1.5",
-                "d3-interpolate": "1.1.6",
-                "d3-path": "1.0.5",
-                "d3-polygon": "1.0.3",
-                "d3-quadtree": "1.0.3",
-                "d3-queue": "3.0.7",
-                "d3-random": "1.1.0",
-                "d3-request": "1.0.6",
-                "d3-scale": "1.0.7",
-                "d3-selection": "1.3.0",
-                "d3-shape": "1.2.0",
-                "d3-time": "1.0.8",
-                "d3-time-format": "2.1.1",
-                "d3-timer": "1.0.7",
-                "d3-transition": "1.1.1",
-                "d3-voronoi": "1.1.2",
-                "d3-zoom": "1.7.1"
+                "d3-array": "3",
+                "d3-axis": "3",
+                "d3-brush": "3",
+                "d3-chord": "3",
+                "d3-color": "3",
+                "d3-contour": "4",
+                "d3-delaunay": "6",
+                "d3-dispatch": "3",
+                "d3-drag": "3",
+                "d3-dsv": "3",
+                "d3-ease": "3",
+                "d3-fetch": "3",
+                "d3-force": "3",
+                "d3-format": "3",
+                "d3-geo": "3",
+                "d3-hierarchy": "3",
+                "d3-interpolate": "3",
+                "d3-path": "3",
+                "d3-polygon": "3",
+                "d3-quadtree": "3",
+                "d3-random": "3",
+                "d3-scale": "4",
+                "d3-scale-chromatic": "3",
+                "d3-selection": "3",
+                "d3-shape": "3",
+                "d3-time": "3",
+                "d3-time-format": "4",
+                "d3-timer": "3",
+                "d3-transition": "3",
+                "d3-zoom": "3"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/d3-array": {
@@ -6321,29 +6324,37 @@
             "integrity": "sha512-CyINJQ0SOUHojDdFDH4JEM0552vCR1utGyLHegJHyYH0JyCpSeTPxi4OBqHMA2jJZq4NH782LtaJWBImqI/HBw=="
         },
         "node_modules/d3-axis": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-1.0.8.tgz",
-            "integrity": "sha512-K0djTb26iQ6AsuD2d6Ka08wBHf4V30awIxV4XFuB/iLzYtTqqJlE/nIN0DBJJCX7lbOqbt2/oeX3r+sU5k2veg=="
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+            "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/d3-brush": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-1.0.4.tgz",
-            "integrity": "sha512-nUFueDzOlvwFvuOBynGSyJM7Wt1H9fKgJeoWFSg3ScS4c7FJBch92FKUJKum4xtgPYHdgH2C3bRg3GzSVltCJQ==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+            "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
             "dependencies": {
-                "d3-dispatch": "1",
-                "d3-drag": "1",
-                "d3-interpolate": "1",
-                "d3-selection": "1",
-                "d3-transition": "1"
+                "d3-dispatch": "1 - 3",
+                "d3-drag": "2 - 3",
+                "d3-interpolate": "1 - 3",
+                "d3-selection": "3",
+                "d3-transition": "3"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/d3-chord": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-1.0.4.tgz",
-            "integrity": "sha512-o0ExexkK1N0KikUakKrQwttP5Flu8AYD6iBUh3AdPJqnTh6xlvcX5wFRuuo29sLOAr9+T4yZPUH1S3CCQJ1SlQ==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+            "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
             "dependencies": {
-                "d3-array": "1",
-                "d3-path": "1"
+                "d3-path": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/d3-collection": {
@@ -6356,81 +6367,178 @@
             "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.0.3.tgz",
             "integrity": "sha512-t+rSOrshj6m2AUOe8kHvTwfUQ5TFoInEkBfmsHHAHPof58dmbRXNpicB7XAyPbMQbcC7i09p2BxeCEdgBd8xmw=="
         },
+        "node_modules/d3-contour": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+            "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+            "dependencies": {
+                "d3-array": "^3.2.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-contour/node_modules/d3-array": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+            "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+            "dependencies": {
+                "internmap": "1 - 2"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-delaunay": {
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+            "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+            "dependencies": {
+                "delaunator": "5"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/d3-dispatch": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.3.tgz",
             "integrity": "sha512-Qh2DR3neW3lq/ug4oymXHYoIsA91nYt47ERb+fPKjRg6zLij06aP7KqHHl2NyziK9ASxrR3GLkHCtZvXe/jMVg=="
         },
         "node_modules/d3-drag": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-1.2.1.tgz",
-            "integrity": "sha512-Cg8/K2rTtzxzrb0fmnYOUeZHvwa4PHzwXOLZZPwtEs2SKLLKLXeYwZKBB+DlOxUvFmarOnmt//cU4+3US2lyyQ==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+            "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
             "dependencies": {
-                "d3-dispatch": "1",
-                "d3-selection": "1"
+                "d3-dispatch": "1 - 3",
+                "d3-selection": "3"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/d3-dsv": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-1.0.8.tgz",
-            "integrity": "sha512-IVCJpQ+YGe3qu6odkPQI0KPqfxkhbP/oM1XhhE/DFiYmcXKfCRub4KXyiuehV1d4drjWVXHUWx4gHqhdZb6n/A==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+            "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
             "dependencies": {
-                "commander": "2",
-                "iconv-lite": "0.4",
+                "commander": "7",
+                "iconv-lite": "0.6",
                 "rw": "1"
             },
             "bin": {
-                "csv2json": "bin/dsv2json",
-                "csv2tsv": "bin/dsv2dsv",
-                "dsv2dsv": "bin/dsv2dsv",
-                "dsv2json": "bin/dsv2json",
-                "json2csv": "bin/json2dsv",
-                "json2dsv": "bin/json2dsv",
-                "json2tsv": "bin/json2dsv",
-                "tsv2csv": "bin/dsv2dsv",
-                "tsv2json": "bin/dsv2json"
+                "csv2json": "bin/dsv2json.js",
+                "csv2tsv": "bin/dsv2dsv.js",
+                "dsv2dsv": "bin/dsv2dsv.js",
+                "dsv2json": "bin/dsv2json.js",
+                "json2csv": "bin/json2dsv.js",
+                "json2dsv": "bin/json2dsv.js",
+                "json2tsv": "bin/json2dsv.js",
+                "tsv2csv": "bin/dsv2dsv.js",
+                "tsv2json": "bin/dsv2json.js"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-dsv/node_modules/commander": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+            "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/d3-dsv/node_modules/iconv-lite": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/d3-ease": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.3.tgz",
-            "integrity": "sha512-io3QwOJwVPAxRF2UXpKpCdz2wm/7VLFCQQ1yy+GzX6YCtt3vi2BGnimI8agSF5jyUrHsADyF303d2S+ps7zU8w=="
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+            "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-fetch": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+            "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+            "dependencies": {
+                "d3-dsv": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/d3-force": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.1.0.tgz",
-            "integrity": "sha512-2HVQz3/VCQs0QeRNZTYb7GxoUCeb6bOzMp/cGcLa87awY9ZsPvXOGeZm0iaGBjXic6I1ysKwMn+g+5jSAdzwcg==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+            "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
             "dependencies": {
-                "d3-collection": "1",
-                "d3-dispatch": "1",
-                "d3-quadtree": "1",
-                "d3-timer": "1"
+                "d3-dispatch": "1 - 3",
+                "d3-quadtree": "1 - 3",
+                "d3-timer": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/d3-format": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.2.2.tgz",
-            "integrity": "sha512-zH9CfF/3C8zUI47nsiKfD0+AGDEuM8LwBIP7pBVpyR4l/sKkZqITmMtxRp04rwBrlshIZ17XeFAaovN3++wzkw=="
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+            "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/d3-geo": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.9.1.tgz",
-            "integrity": "sha512-l9wL/cEQkyZQYXw3xbmLsH3eQ5ij+icNfo4r0GrLa5rOCZR/e/3am45IQ0FvQ5uMsv+77zBRunLc9ufTWSQYFA==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+            "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
             "dependencies": {
-                "d3-array": "1"
+                "d3-array": "2.5.0 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-geo/node_modules/d3-array": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+            "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+            "dependencies": {
+                "internmap": "1 - 2"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/d3-hierarchy": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-1.1.5.tgz",
-            "integrity": "sha512-PcsLIhThc60mWnxlojIOH7Sc0tQ2DgLWfEwEAyzCtej5f3H9wSsRmrg5pEhKZLrwiJnI2zyw/pznJxL9a/Eugw=="
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+            "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/d3-interpolate": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.1.6.tgz",
-            "integrity": "sha512-mOnv5a+pZzkNIHtw/V6I+w9Lqm9L5bG3OTXPM5A+QO0yyVMQ4W1uZhR+VOJmazaOZXri2ppbiZ5BUNWT0pFM9A==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+            "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
             "dependencies": {
-                "d3-color": "1"
+                "d3-color": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/d3-path": {
@@ -6439,54 +6547,82 @@
             "integrity": "sha512-eD76prgnTKYkLzHlY2UMyOEZXTpC+WOanCr1BLxo38w4fPPPq/LgCFqRQvqFU3AJngfZmmKR7rgKPZ4EGJ9Atw=="
         },
         "node_modules/d3-polygon": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-1.0.3.tgz",
-            "integrity": "sha512-2zP7GOvf4XOWTeQouK7fCO534yQxyhYYTw6GTqcXifIalHgA6qV/es+4GRQii9m6XxEPFcht4loobD/o2iEo1A=="
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+            "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/d3-quadtree": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-1.0.3.tgz",
             "integrity": "sha512-U2Jc3jF3JOBGXIOnvWY9C4ekRwRX9hEVpMMmeduJyaxAwPmoe7t84iZFTLn1RwYOyrXxJF55H/Hrg186TFQQdw=="
         },
-        "node_modules/d3-queue": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/d3-queue/-/d3-queue-3.0.7.tgz",
-            "integrity": "sha512-2rs+6pNFKkrJhqe1rg5znw7dKJ7KZr62j9aLZfhondkrnz6U7VRmJj1UGcbD8MRc46c7H8m4SWhab8EalBQrkw=="
-        },
         "node_modules/d3-random": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-1.1.0.tgz",
-            "integrity": "sha512-XuMbjx3Jq4EWfJP4g6nR7zns/bZfaVbWHWfR8auDkEiWCzVbWifmasfszV1ZRN3xXK3nY4RUFL2nTIhceGZSFQ=="
-        },
-        "node_modules/d3-request": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/d3-request/-/d3-request-1.0.6.tgz",
-            "integrity": "sha512-FJj8ySY6GYuAJHZMaCQ83xEYE4KbkPkmxZ3Hu6zA1xxG2GD+z6P+Lyp+zjdsHf0xEbp2xcluDI50rCS855EQ6w==",
-            "dependencies": {
-                "d3-collection": "1",
-                "d3-dispatch": "1",
-                "d3-dsv": "1",
-                "xmlhttprequest": "1"
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+            "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/d3-scale": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
-            "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+            "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
             "dependencies": {
-                "d3-array": "^1.2.0",
-                "d3-collection": "1",
-                "d3-color": "1",
-                "d3-format": "1",
-                "d3-interpolate": "1",
-                "d3-time": "1",
-                "d3-time-format": "2"
+                "d3-array": "2.10.0 - 3",
+                "d3-format": "1 - 3",
+                "d3-interpolate": "1.2.0 - 3",
+                "d3-time": "2.1.1 - 3",
+                "d3-time-format": "2 - 4"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-scale-chromatic": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+            "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+            "dependencies": {
+                "d3-color": "1 - 3",
+                "d3-interpolate": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-scale/node_modules/d3-array": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+            "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+            "dependencies": {
+                "internmap": "1 - 2"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-scale/node_modules/d3-time": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+            "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+            "dependencies": {
+                "d3-array": "2 - 3"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/d3-selection": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.3.0.tgz",
-            "integrity": "sha512-qgpUOg9tl5CirdqESUAu0t9MU/t3O9klYfGfyKsXEmhyxyzLpzpeh08gaxBUTQw1uXIOkr/30Ut2YRjSSxlmHA=="
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+            "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/d3-shape": {
             "version": "1.2.0",
@@ -6502,11 +6638,14 @@
             "integrity": "sha512-YRZkNhphZh3KcnBfitvF3c6E0JOFGikHZ4YqD+Lzv83ZHn1/u6yGenRU1m+KAk9J1GnZMnKcrtfvSktlA1DXNQ=="
         },
         "node_modules/d3-time-format": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.1.1.tgz",
-            "integrity": "sha512-8kAkymq2WMfzW7e+s/IUNAtN/y3gZXGRrdGfo6R8NKPAA85UBTxZg5E61bR6nLwjPjj4d3zywSQe1CkYLPFyrw==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+            "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
             "dependencies": {
-                "d3-time": "1"
+                "d3-time": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/d3-timer": {
@@ -6515,33 +6654,109 @@
             "integrity": "sha512-vMZXR88XujmG/L5oB96NNKH5lCWwiLM/S2HyyAQLcjWJCloK5shxta4CwOFYLZoY3AWX73v8Lgv4cCAdWtRmOA=="
         },
         "node_modules/d3-transition": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-1.1.1.tgz",
-            "integrity": "sha512-xeg8oggyQ+y5eb4J13iDgKIjUcEfIOZs2BqV/eEmXm2twx80wTzJ4tB4vaZ5BKfz7XsI/DFmQL5me6O27/5ykQ==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+            "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
             "dependencies": {
-                "d3-color": "1",
-                "d3-dispatch": "1",
-                "d3-ease": "1",
-                "d3-interpolate": "1",
-                "d3-selection": "^1.1.0",
-                "d3-timer": "1"
+                "d3-color": "1 - 3",
+                "d3-dispatch": "1 - 3",
+                "d3-ease": "1 - 3",
+                "d3-interpolate": "1 - 3",
+                "d3-timer": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "peerDependencies": {
+                "d3-selection": "2 - 3"
             }
         },
-        "node_modules/d3-voronoi": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.2.tgz",
-            "integrity": "sha512-RhGS1u2vavcO7ay7ZNAPo4xeDh/VYeGof3x5ZLJBQgYhLegxr3s5IykvWmJ94FTU6mcbtp4sloqZ54mP6R4Utw=="
-        },
         "node_modules/d3-zoom": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-1.7.1.tgz",
-            "integrity": "sha512-sZHQ55DGq5BZBFGnRshUT8tm2sfhPHFnOlmPbbwTkAoPeVdRTkB4Xsf9GCY0TSHrTD8PeJPZGmP/TpGicwJDJQ==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+            "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
             "dependencies": {
-                "d3-dispatch": "1",
-                "d3-drag": "1",
-                "d3-interpolate": "1",
-                "d3-selection": "1",
-                "d3-transition": "1"
+                "d3-dispatch": "1 - 3",
+                "d3-drag": "2 - 3",
+                "d3-interpolate": "1 - 3",
+                "d3-selection": "2 - 3",
+                "d3-transition": "2 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3/node_modules/d3-array": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+            "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+            "dependencies": {
+                "internmap": "1 - 2"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3/node_modules/d3-color": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+            "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3/node_modules/d3-dispatch": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+            "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3/node_modules/d3-path": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+            "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3/node_modules/d3-quadtree": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+            "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3/node_modules/d3-shape": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+            "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+            "dependencies": {
+                "d3-path": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3/node_modules/d3-time": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+            "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+            "dependencies": {
+                "d3-array": "2 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3/node_modules/d3-timer": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+            "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/dashdash": {
@@ -6744,6 +6959,14 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/delaunator": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
+            "integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
+            "dependencies": {
+                "robust-predicates": "^3.0.2"
             }
         },
         "node_modules/delaunay-triangulate": {
@@ -9893,6 +10116,7 @@
             "version": "0.4.24",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
             "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "dev": true,
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3"
             },
@@ -10031,6 +10255,14 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/internmap": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+            "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/interpret": {
@@ -15794,6 +16026,11 @@
                 "two-product": "^1.0.2"
             }
         },
+        "node_modules/robust-predicates": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
+            "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="
+        },
         "node_modules/robust-product": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/robust-product/-/robust-product-1.0.0.tgz",
@@ -18621,9 +18858,9 @@
             "dev": true
         },
         "node_modules/xml-utils": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.9.0.tgz",
-            "integrity": "sha512-bE++owdhr9WNSar5MAL04c727SjSHyEtu2+0hTVbHPeJgzauy5bnhfJV3gdKwm4m+ZNjKmjM97WphKwxWqW1IA=="
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.10.1.tgz",
+            "integrity": "sha512-Dn6vJ1Z9v1tepSjvnCpwk5QqwIPcEFKdgnjqfYOABv1ngSofuAhtlugcUC3ehS1OHdgDWSG6C5mvj+Qm15udTQ=="
         },
         "node_modules/xmlhttprequest": {
             "version": "1.8.0",
@@ -18747,9 +18984,9 @@
             "integrity": "sha512-ts+Z8g/xTJaD+g9fAElEJbclk1L0xDsHy6ioq9N5T4j5WPew46WvZ/794Vxnn9N06KyjkCO6zc4JEl7ZZRSa5Q=="
         },
         "@aics/volume-viewer": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/@aics/volume-viewer/-/volume-viewer-3.9.0.tgz",
-            "integrity": "sha512-+ftd8aArxi/ICMqrkuGf2Cq98bb4heM4tdy6iyN2B+by9adLKqeIfyaNGcW/WlePeCD9oxV+rdICvlKnNBLM4w==",
+            "version": "3.11.1",
+            "resolved": "https://registry.npmjs.org/@aics/volume-viewer/-/volume-viewer-3.11.1.tgz",
+            "integrity": "sha512-aFG9SPHK0ddsqj2jcbKPMWF9UTuCsSg9J3kDXWLbmG7XQRKcnJ0R5KTQ9UegYG6OXdDFEPDI4lTKe5/IhJtgJw==",
             "requires": {
                 "geotiff": "^2.0.5",
                 "serialize-error": "^11.0.3",
@@ -18759,17 +18996,17 @@
             }
         },
         "@aics/web-3d-viewer": {
-            "version": "2.9.0",
-            "resolved": "https://registry.npmjs.org/@aics/web-3d-viewer/-/web-3d-viewer-2.9.0.tgz",
-            "integrity": "sha512-grGrc8v1cvBmSpGp/s2tqjpkUMrdNLoHu+zXch0A9SFJZQSXDj6cKvrxG0PEqt6CJK8e/Cvturv6GuzGkT+Rig==",
+            "version": "2.9.2",
+            "resolved": "https://registry.npmjs.org/@aics/web-3d-viewer/-/web-3d-viewer-2.9.2.tgz",
+            "integrity": "sha512-D16TLphuHUMMXbu7xH8WO+kXj4mOkME9nrkIyK0SfRW43anBlv1YWufSh1wgXpr69cnykY83cMkNSX9LwtV6eA==",
             "requires": {
-                "@aics/volume-viewer": "^3.9.0",
+                "@aics/volume-viewer": "^3.11.0",
                 "@ant-design/icons": "^5.2.5",
                 "@fortawesome/fontawesome-svg-core": "^6.5.2",
                 "@fortawesome/free-solid-svg-icons": "^6.5.2",
                 "@fortawesome/react-fontawesome": "^0.2.0",
                 "color-string": "^1.5.3",
-                "d3": "^4.11.0",
+                "d3": "^7.9.0",
                 "fuse.js": "^7.0.0",
                 "lodash": "^4.17.20",
                 "nouislider-react": "^3.4.0",
@@ -23564,40 +23801,91 @@
             }
         },
         "d3": {
-            "version": "4.13.0",
-            "resolved": "https://registry.npmjs.org/d3/-/d3-4.13.0.tgz",
-            "integrity": "sha512-l8c4+0SldjVKLaE2WG++EQlqD7mh/dmQjvi2L2lKPadAVC+TbJC4ci7Uk9bRi+To0+ansgsS0iWfPjD7DBy+FQ==",
+            "version": "7.9.0",
+            "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+            "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
             "requires": {
-                "d3-array": "1.2.1",
-                "d3-axis": "1.0.8",
-                "d3-brush": "1.0.4",
-                "d3-chord": "1.0.4",
-                "d3-collection": "1.0.4",
-                "d3-color": "1.0.3",
-                "d3-dispatch": "1.0.3",
-                "d3-drag": "1.2.1",
-                "d3-dsv": "1.0.8",
-                "d3-ease": "1.0.3",
-                "d3-force": "1.1.0",
-                "d3-format": "1.2.2",
-                "d3-geo": "1.9.1",
-                "d3-hierarchy": "1.1.5",
-                "d3-interpolate": "1.1.6",
-                "d3-path": "1.0.5",
-                "d3-polygon": "1.0.3",
-                "d3-quadtree": "1.0.3",
-                "d3-queue": "3.0.7",
-                "d3-random": "1.1.0",
-                "d3-request": "1.0.6",
-                "d3-scale": "1.0.7",
-                "d3-selection": "1.3.0",
-                "d3-shape": "1.2.0",
-                "d3-time": "1.0.8",
-                "d3-time-format": "2.1.1",
-                "d3-timer": "1.0.7",
-                "d3-transition": "1.1.1",
-                "d3-voronoi": "1.1.2",
-                "d3-zoom": "1.7.1"
+                "d3-array": "3",
+                "d3-axis": "3",
+                "d3-brush": "3",
+                "d3-chord": "3",
+                "d3-color": "3",
+                "d3-contour": "4",
+                "d3-delaunay": "6",
+                "d3-dispatch": "3",
+                "d3-drag": "3",
+                "d3-dsv": "3",
+                "d3-ease": "3",
+                "d3-fetch": "3",
+                "d3-force": "3",
+                "d3-format": "3",
+                "d3-geo": "3",
+                "d3-hierarchy": "3",
+                "d3-interpolate": "3",
+                "d3-path": "3",
+                "d3-polygon": "3",
+                "d3-quadtree": "3",
+                "d3-random": "3",
+                "d3-scale": "4",
+                "d3-scale-chromatic": "3",
+                "d3-selection": "3",
+                "d3-shape": "3",
+                "d3-time": "3",
+                "d3-time-format": "4",
+                "d3-timer": "3",
+                "d3-transition": "3",
+                "d3-zoom": "3"
+            },
+            "dependencies": {
+                "d3-array": {
+                    "version": "3.2.4",
+                    "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+                    "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+                    "requires": {
+                        "internmap": "1 - 2"
+                    }
+                },
+                "d3-color": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+                    "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="
+                },
+                "d3-dispatch": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+                    "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="
+                },
+                "d3-path": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+                    "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="
+                },
+                "d3-quadtree": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+                    "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="
+                },
+                "d3-shape": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+                    "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+                    "requires": {
+                        "d3-path": "^3.1.0"
+                    }
+                },
+                "d3-time": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+                    "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+                    "requires": {
+                        "d3-array": "2 - 3"
+                    }
+                },
+                "d3-timer": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+                    "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="
+                }
             }
         },
         "d3-array": {
@@ -23606,29 +23894,28 @@
             "integrity": "sha512-CyINJQ0SOUHojDdFDH4JEM0552vCR1utGyLHegJHyYH0JyCpSeTPxi4OBqHMA2jJZq4NH782LtaJWBImqI/HBw=="
         },
         "d3-axis": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-1.0.8.tgz",
-            "integrity": "sha512-K0djTb26iQ6AsuD2d6Ka08wBHf4V30awIxV4XFuB/iLzYtTqqJlE/nIN0DBJJCX7lbOqbt2/oeX3r+sU5k2veg=="
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+            "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw=="
         },
         "d3-brush": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-1.0.4.tgz",
-            "integrity": "sha512-nUFueDzOlvwFvuOBynGSyJM7Wt1H9fKgJeoWFSg3ScS4c7FJBch92FKUJKum4xtgPYHdgH2C3bRg3GzSVltCJQ==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+            "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
             "requires": {
-                "d3-dispatch": "1",
-                "d3-drag": "1",
-                "d3-interpolate": "1",
-                "d3-selection": "1",
-                "d3-transition": "1"
+                "d3-dispatch": "1 - 3",
+                "d3-drag": "2 - 3",
+                "d3-interpolate": "1 - 3",
+                "d3-selection": "3",
+                "d3-transition": "3"
             }
         },
         "d3-chord": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-1.0.4.tgz",
-            "integrity": "sha512-o0ExexkK1N0KikUakKrQwttP5Flu8AYD6iBUh3AdPJqnTh6xlvcX5wFRuuo29sLOAr9+T4yZPUH1S3CCQJ1SlQ==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+            "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
             "requires": {
-                "d3-array": "1",
-                "d3-path": "1"
+                "d3-path": "1 - 3"
             }
         },
         "d3-collection": {
@@ -23641,70 +23928,128 @@
             "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.0.3.tgz",
             "integrity": "sha512-t+rSOrshj6m2AUOe8kHvTwfUQ5TFoInEkBfmsHHAHPof58dmbRXNpicB7XAyPbMQbcC7i09p2BxeCEdgBd8xmw=="
         },
+        "d3-contour": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+            "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+            "requires": {
+                "d3-array": "^3.2.0"
+            },
+            "dependencies": {
+                "d3-array": {
+                    "version": "3.2.4",
+                    "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+                    "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+                    "requires": {
+                        "internmap": "1 - 2"
+                    }
+                }
+            }
+        },
+        "d3-delaunay": {
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+            "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+            "requires": {
+                "delaunator": "5"
+            }
+        },
         "d3-dispatch": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.3.tgz",
             "integrity": "sha512-Qh2DR3neW3lq/ug4oymXHYoIsA91nYt47ERb+fPKjRg6zLij06aP7KqHHl2NyziK9ASxrR3GLkHCtZvXe/jMVg=="
         },
         "d3-drag": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-1.2.1.tgz",
-            "integrity": "sha512-Cg8/K2rTtzxzrb0fmnYOUeZHvwa4PHzwXOLZZPwtEs2SKLLKLXeYwZKBB+DlOxUvFmarOnmt//cU4+3US2lyyQ==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+            "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
             "requires": {
-                "d3-dispatch": "1",
-                "d3-selection": "1"
+                "d3-dispatch": "1 - 3",
+                "d3-selection": "3"
             }
         },
         "d3-dsv": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-1.0.8.tgz",
-            "integrity": "sha512-IVCJpQ+YGe3qu6odkPQI0KPqfxkhbP/oM1XhhE/DFiYmcXKfCRub4KXyiuehV1d4drjWVXHUWx4gHqhdZb6n/A==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+            "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
             "requires": {
-                "commander": "2",
-                "iconv-lite": "0.4",
+                "commander": "7",
+                "iconv-lite": "0.6",
                 "rw": "1"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+                    "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
+                },
+                "iconv-lite": {
+                    "version": "0.6.3",
+                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+                    "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+                    "requires": {
+                        "safer-buffer": ">= 2.1.2 < 3.0.0"
+                    }
+                }
             }
         },
         "d3-ease": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.3.tgz",
-            "integrity": "sha512-io3QwOJwVPAxRF2UXpKpCdz2wm/7VLFCQQ1yy+GzX6YCtt3vi2BGnimI8agSF5jyUrHsADyF303d2S+ps7zU8w=="
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+            "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="
+        },
+        "d3-fetch": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+            "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+            "requires": {
+                "d3-dsv": "1 - 3"
+            }
         },
         "d3-force": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.1.0.tgz",
-            "integrity": "sha512-2HVQz3/VCQs0QeRNZTYb7GxoUCeb6bOzMp/cGcLa87awY9ZsPvXOGeZm0iaGBjXic6I1ysKwMn+g+5jSAdzwcg==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+            "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
             "requires": {
-                "d3-collection": "1",
-                "d3-dispatch": "1",
-                "d3-quadtree": "1",
-                "d3-timer": "1"
+                "d3-dispatch": "1 - 3",
+                "d3-quadtree": "1 - 3",
+                "d3-timer": "1 - 3"
             }
         },
         "d3-format": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.2.2.tgz",
-            "integrity": "sha512-zH9CfF/3C8zUI47nsiKfD0+AGDEuM8LwBIP7pBVpyR4l/sKkZqITmMtxRp04rwBrlshIZ17XeFAaovN3++wzkw=="
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+            "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA=="
         },
         "d3-geo": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.9.1.tgz",
-            "integrity": "sha512-l9wL/cEQkyZQYXw3xbmLsH3eQ5ij+icNfo4r0GrLa5rOCZR/e/3am45IQ0FvQ5uMsv+77zBRunLc9ufTWSQYFA==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+            "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
             "requires": {
-                "d3-array": "1"
+                "d3-array": "2.5.0 - 3"
+            },
+            "dependencies": {
+                "d3-array": {
+                    "version": "3.2.4",
+                    "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+                    "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+                    "requires": {
+                        "internmap": "1 - 2"
+                    }
+                }
             }
         },
         "d3-hierarchy": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-1.1.5.tgz",
-            "integrity": "sha512-PcsLIhThc60mWnxlojIOH7Sc0tQ2DgLWfEwEAyzCtej5f3H9wSsRmrg5pEhKZLrwiJnI2zyw/pznJxL9a/Eugw=="
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+            "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA=="
         },
         "d3-interpolate": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.1.6.tgz",
-            "integrity": "sha512-mOnv5a+pZzkNIHtw/V6I+w9Lqm9L5bG3OTXPM5A+QO0yyVMQ4W1uZhR+VOJmazaOZXri2ppbiZ5BUNWT0pFM9A==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+            "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
             "requires": {
-                "d3-color": "1"
+                "d3-color": "1 - 3"
             }
         },
         "d3-path": {
@@ -23713,54 +24058,63 @@
             "integrity": "sha512-eD76prgnTKYkLzHlY2UMyOEZXTpC+WOanCr1BLxo38w4fPPPq/LgCFqRQvqFU3AJngfZmmKR7rgKPZ4EGJ9Atw=="
         },
         "d3-polygon": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-1.0.3.tgz",
-            "integrity": "sha512-2zP7GOvf4XOWTeQouK7fCO534yQxyhYYTw6GTqcXifIalHgA6qV/es+4GRQii9m6XxEPFcht4loobD/o2iEo1A=="
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+            "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg=="
         },
         "d3-quadtree": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-1.0.3.tgz",
             "integrity": "sha512-U2Jc3jF3JOBGXIOnvWY9C4ekRwRX9hEVpMMmeduJyaxAwPmoe7t84iZFTLn1RwYOyrXxJF55H/Hrg186TFQQdw=="
         },
-        "d3-queue": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/d3-queue/-/d3-queue-3.0.7.tgz",
-            "integrity": "sha512-2rs+6pNFKkrJhqe1rg5znw7dKJ7KZr62j9aLZfhondkrnz6U7VRmJj1UGcbD8MRc46c7H8m4SWhab8EalBQrkw=="
-        },
         "d3-random": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-1.1.0.tgz",
-            "integrity": "sha512-XuMbjx3Jq4EWfJP4g6nR7zns/bZfaVbWHWfR8auDkEiWCzVbWifmasfszV1ZRN3xXK3nY4RUFL2nTIhceGZSFQ=="
-        },
-        "d3-request": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/d3-request/-/d3-request-1.0.6.tgz",
-            "integrity": "sha512-FJj8ySY6GYuAJHZMaCQ83xEYE4KbkPkmxZ3Hu6zA1xxG2GD+z6P+Lyp+zjdsHf0xEbp2xcluDI50rCS855EQ6w==",
-            "requires": {
-                "d3-collection": "1",
-                "d3-dispatch": "1",
-                "d3-dsv": "1",
-                "xmlhttprequest": "1"
-            }
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+            "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ=="
         },
         "d3-scale": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
-            "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+            "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
             "requires": {
-                "d3-array": "^1.2.0",
-                "d3-collection": "1",
-                "d3-color": "1",
-                "d3-format": "1",
-                "d3-interpolate": "1",
-                "d3-time": "1",
-                "d3-time-format": "2"
+                "d3-array": "2.10.0 - 3",
+                "d3-format": "1 - 3",
+                "d3-interpolate": "1.2.0 - 3",
+                "d3-time": "2.1.1 - 3",
+                "d3-time-format": "2 - 4"
+            },
+            "dependencies": {
+                "d3-array": {
+                    "version": "3.2.4",
+                    "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+                    "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+                    "requires": {
+                        "internmap": "1 - 2"
+                    }
+                },
+                "d3-time": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+                    "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+                    "requires": {
+                        "d3-array": "2 - 3"
+                    }
+                }
+            }
+        },
+        "d3-scale-chromatic": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+            "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+            "requires": {
+                "d3-color": "1 - 3",
+                "d3-interpolate": "1 - 3"
             }
         },
         "d3-selection": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.3.0.tgz",
-            "integrity": "sha512-qgpUOg9tl5CirdqESUAu0t9MU/t3O9klYfGfyKsXEmhyxyzLpzpeh08gaxBUTQw1uXIOkr/30Ut2YRjSSxlmHA=="
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+            "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="
         },
         "d3-shape": {
             "version": "1.2.0",
@@ -23776,11 +24130,11 @@
             "integrity": "sha512-YRZkNhphZh3KcnBfitvF3c6E0JOFGikHZ4YqD+Lzv83ZHn1/u6yGenRU1m+KAk9J1GnZMnKcrtfvSktlA1DXNQ=="
         },
         "d3-time-format": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.1.1.tgz",
-            "integrity": "sha512-8kAkymq2WMfzW7e+s/IUNAtN/y3gZXGRrdGfo6R8NKPAA85UBTxZg5E61bR6nLwjPjj4d3zywSQe1CkYLPFyrw==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+            "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
             "requires": {
-                "d3-time": "1"
+                "d3-time": "1 - 3"
             }
         },
         "d3-timer": {
@@ -23789,33 +24143,27 @@
             "integrity": "sha512-vMZXR88XujmG/L5oB96NNKH5lCWwiLM/S2HyyAQLcjWJCloK5shxta4CwOFYLZoY3AWX73v8Lgv4cCAdWtRmOA=="
         },
         "d3-transition": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-1.1.1.tgz",
-            "integrity": "sha512-xeg8oggyQ+y5eb4J13iDgKIjUcEfIOZs2BqV/eEmXm2twx80wTzJ4tB4vaZ5BKfz7XsI/DFmQL5me6O27/5ykQ==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+            "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
             "requires": {
-                "d3-color": "1",
-                "d3-dispatch": "1",
-                "d3-ease": "1",
-                "d3-interpolate": "1",
-                "d3-selection": "^1.1.0",
-                "d3-timer": "1"
+                "d3-color": "1 - 3",
+                "d3-dispatch": "1 - 3",
+                "d3-ease": "1 - 3",
+                "d3-interpolate": "1 - 3",
+                "d3-timer": "1 - 3"
             }
         },
-        "d3-voronoi": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.2.tgz",
-            "integrity": "sha512-RhGS1u2vavcO7ay7ZNAPo4xeDh/VYeGof3x5ZLJBQgYhLegxr3s5IykvWmJ94FTU6mcbtp4sloqZ54mP6R4Utw=="
-        },
         "d3-zoom": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-1.7.1.tgz",
-            "integrity": "sha512-sZHQ55DGq5BZBFGnRshUT8tm2sfhPHFnOlmPbbwTkAoPeVdRTkB4Xsf9GCY0TSHrTD8PeJPZGmP/TpGicwJDJQ==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+            "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
             "requires": {
-                "d3-dispatch": "1",
-                "d3-drag": "1",
-                "d3-interpolate": "1",
-                "d3-selection": "1",
-                "d3-transition": "1"
+                "d3-dispatch": "1 - 3",
+                "d3-drag": "2 - 3",
+                "d3-interpolate": "1 - 3",
+                "d3-selection": "2 - 3",
+                "d3-transition": "2 - 3"
             }
         },
         "dashdash": {
@@ -23977,6 +24325,14 @@
                         }
                     }
                 }
+            }
+        },
+        "delaunator": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
+            "integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
+            "requires": {
+                "robust-predicates": "^3.0.2"
             }
         },
         "delaunay-triangulate": {
@@ -26536,6 +26892,7 @@
             "version": "0.4.24",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
             "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "dev": true,
             "requires": {
                 "safer-buffer": ">= 2.1.2 < 3"
             }
@@ -26629,6 +26986,11 @@
                 "hasown": "^2.0.0",
                 "side-channel": "^1.0.4"
             }
+        },
+        "internmap": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+            "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="
         },
         "interpret": {
             "version": "2.2.0",
@@ -31154,6 +31516,11 @@
                 "two-product": "^1.0.2"
             }
         },
+        "robust-predicates": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
+            "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="
+        },
         "robust-product": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/robust-product/-/robust-product-1.0.0.tgz",
@@ -33336,9 +33703,9 @@
             "dev": true
         },
         "xml-utils": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.9.0.tgz",
-            "integrity": "sha512-bE++owdhr9WNSar5MAL04c727SjSHyEtu2+0hTVbHPeJgzauy5bnhfJV3gdKwm4m+ZNjKmjM97WphKwxWqW1IA=="
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.10.1.tgz",
+            "integrity": "sha512-Dn6vJ1Z9v1tepSjvnCpwk5QqwIPcEFKdgnjqfYOABv1ngSofuAhtlugcUC3ehS1OHdgDWSG6C5mvj+Qm15udTQ=="
         },
         "xmlhttprequest": {
             "version": "1.8.0",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     },
     "dependencies": {
         "@aics/browsing-context-messaging": "~1.1",
-        "@aics/web-3d-viewer": "^2.9.0",
+        "@aics/web-3d-viewer": "^2.9.2",
         "@ant-design/icons": "^4.2.2",
         "antd": "^5.17.4",
         "axios": "^0.21.1",

--- a/src/components/CellViewer/index.tsx
+++ b/src/components/CellViewer/index.tsx
@@ -1,4 +1,4 @@
-import { ImageViewerApp } from "@aics/web-3d-viewer";
+import { ImageViewerApp, ViewerStateProvider } from "@aics/web-3d-viewer";
 import React from "react";
 
 import styles from "./style.css";
@@ -19,19 +19,21 @@ const CellViewer: React.FunctionComponent<VolumeViewerProps> = (props) => {
 
     return (
         <div className={styles.cellViewerContainer} style={CONTAINER_STYLE}>
-            <ImageViewerApp
-                cellId={props.cellId}
-                imageUrl={props.baseUrl + props.cellPath}
-                parentImageDownloadHref={props.fovDownloadHref}
-                imageDownloadHref={props.cellDownloadHref}
-                parentImageUrl={props.baseUrl + props.fovPath}
-                viewerChannelSettings={props.viewerChannelSettings}
-                transform={props.transform}
-                onControlPanelToggle={props.onControlPanelToggle}
-                metadata={props.metadata}
-                appHeight="100%"
-                canvasMargin="0 0 0 0"
-            />
+            <ViewerStateProvider>
+                <ImageViewerApp
+                    cellId={props.cellId}
+                    imageUrl={props.baseUrl + props.cellPath}
+                    imageDownloadHref={props.cellDownloadHref}
+                    parentImageUrl={props.fovPath ? props.baseUrl + props.fovPath : ""}
+                    parentImageDownloadHref={props.fovDownloadHref}
+                    viewerChannelSettings={props.viewerChannelSettings}
+                    transform={props.transform}
+                    onControlPanelToggle={props.onControlPanelToggle}
+                    metadata={props.metadata}
+                    appHeight="100%"
+                    canvasMargin="0 0 0 0"
+                />
+            </ViewerStateProvider>
         </div>
     );
 };

--- a/src/containers/Cfe/index.tsx
+++ b/src/containers/Cfe/index.tsx
@@ -77,6 +77,9 @@ class Cfe extends React.Component<CfeProps, CfeState> {
     public componentDidUpdate = (prevProps: CfeProps, prevState: CfeState) => {
         const { currentTab } = this.state;
         if (this.props.showAlignControl) {
+            this.alignContainer.style.setProperty("display", "flex");
+            this.alignContainer.style.setProperty("text-wrap", "nowrap");
+            this.alignContainer.style.setProperty("margin-right", "6px");
             document.querySelector(".viewer-toolbar-left")?.prepend(this.alignContainer);
         }
         if (prevState.currentTab !== currentTab && currentTab === VIEWER_TAB_KEY) {


### PR DESCRIPTION
Problem
=======
Closes #174, "full field is still visible for datasets without it."

I've thrown in a couple other misc. changes but this is a small PR (<20 lines). Most of the line count comes from dependency changes.

*Estimated review size: tiny, <5 minutes*

Solution
========
- Passes an empty string if the `fovPath` is an empty string.
- Fixes formatting on the left toolbar in the viewport.
- Adds the `ViewerStateProvider` as per the new W3CV API.
- Upgrade web-3d-viewer to v2.9.2

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Clone and run `npm run start`.
2. Open http://localhost:9002/?cellSelectedFor3D=439543&colorBy=cell-line&dataset=variance_v1&plotByOnX=cell-volume&plotByOnY=dna-volume&selectedPoint%5B0%5D=439543. You should see the full field toggle.
3. Open http://localhost:9002/?cellSelectedFor3D=F2492C26&colorBy=cell-age&dataset=cellsystems_live_v2021.1&plotByOnX=expert-score&plotByOnY=cos&selectedPoint%5B0%5D=F2492C26. You should not see the full field toggle.

Screenshots (optional):
-----------------------
Full field available:
![image](https://github.com/user-attachments/assets/025989fc-ecd8-4641-b5cc-5f6c836f97b3)

Full field not available:
![image](https://github.com/user-attachments/assets/2c28fc64-8e63-4e49-b381-269bf14057be)
