### PR TITLE
fix: Fixed cell masking and closed loader error message by updating w3cv dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "ISC",
             "dependencies": {
                 "@aics/browsing-context-messaging": "~1.1",
-                "@aics/web-3d-viewer": "^2.10.2",
+                "@aics/web-3d-viewer": "^2.10.3",
                 "@ant-design/icons": "^4.2.2",
                 "antd": "^5.17.4",
                 "axios": "^1.7.7",
@@ -103,23 +103,30 @@
             "license": "MIT"
         },
         "node_modules/@aics/volume-viewer": {
-            "version": "3.11.2",
-            "resolved": "https://registry.npmjs.org/@aics/volume-viewer/-/volume-viewer-3.11.2.tgz",
-            "integrity": "sha512-lmYgBFirjpHVjN4Wb/ywmeUQeBqQQXpWP9D606ooXDeBsPJs+bLGfEiVgE4qj+O/3nLInLMthilcH+tcqK1JfQ==",
+            "version": "3.12.2",
+            "resolved": "https://registry.npmjs.org/@aics/volume-viewer/-/volume-viewer-3.12.2.tgz",
+            "integrity": "sha512-YRL7gYqQcjiudaHyFXPyCqPMKZkUq+pJ4gXTlgEwcNV2ozLei8/xMlJdi6bmvPTDbTyeii2N3mgsJZT2dGXkqw==",
             "dependencies": {
+                "@babel/runtime": "^7.25.6",
                 "geotiff": "^2.0.5",
                 "serialize-error": "^11.0.3",
-                "three": "^0.144.0",
+                "three": "^0.162.0",
+                "throttled-queue": "^2.1.4",
                 "tweakpane": "^3.1.9",
                 "zarrita": "^0.3.2"
             }
         },
+        "node_modules/@aics/volume-viewer/node_modules/three": {
+            "version": "0.162.0",
+            "resolved": "https://registry.npmjs.org/three/-/three-0.162.0.tgz",
+            "integrity": "sha512-xfCYj4RnlozReCmUd+XQzj6/5OjDNHBy5nT6rVwrOKGENAvpXe2z1jL+DZYaMu4/9pNsjH/4Os/VvS9IrH7IOQ=="
+        },
         "node_modules/@aics/web-3d-viewer": {
-            "version": "2.10.2",
-            "resolved": "https://registry.npmjs.org/@aics/web-3d-viewer/-/web-3d-viewer-2.10.2.tgz",
-            "integrity": "sha512-8GE9ZQkeCK5XDIxN/wlvk2XU2CasMc9Lu71BMo5L3e3mAE1rwnT8tkmRWO95seq3bhcTB57NeB56yNyMwh2KVg==",
+            "version": "2.10.3",
+            "resolved": "https://registry.npmjs.org/@aics/web-3d-viewer/-/web-3d-viewer-2.10.3.tgz",
+            "integrity": "sha512-9RbW3H2UI/jaVj7RjvsJJCjh4dOSJGt9apKSESrqW4tW6uwFSvZiadyxfQp8m/GyCyN5IKNkm8wwQIjjtzS/4g==",
             "dependencies": {
-                "@aics/volume-viewer": "^3.11.2",
+                "@aics/volume-viewer": "^3.12.2",
                 "@ant-design/icons": "^5.2.5",
                 "@fortawesome/fontawesome-svg-core": "^6.5.2",
                 "@fortawesome/free-solid-svg-icons": "^6.5.2",
@@ -3712,9 +3719,9 @@
             }
         },
         "node_modules/@petamoriken/float16": {
-            "version": "3.8.7",
-            "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.8.7.tgz",
-            "integrity": "sha512-/Ri4xDDpe12NT6Ex/DRgHzLlobiQXEW/hmG08w1wj/YU7hLemk97c+zHQFp0iZQ9r7YqgLEXZR2sls4HxBf9NA=="
+            "version": "3.9.0",
+            "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.9.0.tgz",
+            "integrity": "sha512-rYUZ+VFjPHD0NT2JYKj64NxXxrV642IiyaUxxorTEj0S3hT7B5Ixezyc9Fn+XvSk0ETEBp5VWjGIErzh0ug0Xw=="
         },
         "node_modules/@plotly/d3": {
             "version": "3.8.2",
@@ -15544,7 +15551,8 @@
         "node_modules/three": {
             "version": "0.144.0",
             "resolved": "https://registry.npmjs.org/three/-/three-0.144.0.tgz",
-            "integrity": "sha512-R8AXPuqfjfRJKkYoTQcTK7A6i3AdO9++2n8ubya/GTU+fEHhYKu1ZooRSCPkx69jbnzT7dD/xEo6eROQTt2lJw=="
+            "integrity": "sha512-R8AXPuqfjfRJKkYoTQcTK7A6i3AdO9++2n8ubya/GTU+fEHhYKu1ZooRSCPkx69jbnzT7dD/xEo6eROQTt2lJw==",
+            "peer": true
         },
         "node_modules/throttle-debounce": {
             "version": "5.0.0",
@@ -15552,6 +15560,11 @@
             "engines": {
                 "node": ">=12.22"
             }
+        },
+        "node_modules/throttled-queue": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/throttled-queue/-/throttled-queue-2.1.4.tgz",
+            "integrity": "sha512-YGdk8sdmr4ge3g+doFj/7RLF5kLM+Mi7DEciu9PHxnMJZMeVuZeTj31g4VE7ekUffx/IdbvrtOCiz62afg0mkg=="
         },
         "node_modules/through2": {
             "version": "0.6.5",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     },
     "dependencies": {
         "@aics/browsing-context-messaging": "~1.1",
-        "@aics/web-3d-viewer": "^2.10.2",
+        "@aics/web-3d-viewer": "^2.10.3",
         "@ant-design/icons": "^4.2.2",
         "antd": "^5.17.4",
         "axios": "^1.7.7",


### PR DESCRIPTION
Problem
=======
Closes #216 ("Cell masking doesn't reset when switching between XY views") and #220 ("Error: Tried to use a closed loader when switching between XY modes")

I tested it locally and both issues have been resolved! Huge thank you to @toloudis for doing the bug hunting for #220.

Solution
========
- Updates w3cv dependency to use the new patched version!