### PR TITLE
refactor: Bump web-3d-viewer to 2.10.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "ISC",
             "dependencies": {
                 "@aics/browsing-context-messaging": "~1.1",
-                "@aics/web-3d-viewer": "^2.10.3",
+                "@aics/web-3d-viewer": "^2.10.4",
                 "@ant-design/icons": "^4.2.2",
                 "antd": "^5.17.4",
                 "axios": "^1.7.7",
@@ -103,30 +103,30 @@
             "license": "MIT"
         },
         "node_modules/@aics/volume-viewer": {
-            "version": "3.12.2",
-            "resolved": "https://registry.npmjs.org/@aics/volume-viewer/-/volume-viewer-3.12.2.tgz",
-            "integrity": "sha512-YRL7gYqQcjiudaHyFXPyCqPMKZkUq+pJ4gXTlgEwcNV2ozLei8/xMlJdi6bmvPTDbTyeii2N3mgsJZT2dGXkqw==",
+            "version": "3.12.3",
+            "resolved": "https://registry.npmjs.org/@aics/volume-viewer/-/volume-viewer-3.12.3.tgz",
+            "integrity": "sha512-iH4BgfucChsaQO6/WEf3rBMnyCETXONhBmhkHKKX3YrJ8hzswEw1NlgBUFKCj5xUxB1K943xVCRgQolYoBbfGA==",
             "dependencies": {
                 "@babel/runtime": "^7.25.6",
                 "geotiff": "^2.0.5",
                 "serialize-error": "^11.0.3",
-                "three": "^0.162.0",
+                "three": "^0.171.0",
                 "throttled-queue": "^2.1.4",
                 "tweakpane": "^3.1.9",
                 "zarrita": "^0.3.2"
             }
         },
         "node_modules/@aics/volume-viewer/node_modules/three": {
-            "version": "0.162.0",
-            "resolved": "https://registry.npmjs.org/three/-/three-0.162.0.tgz",
-            "integrity": "sha512-xfCYj4RnlozReCmUd+XQzj6/5OjDNHBy5nT6rVwrOKGENAvpXe2z1jL+DZYaMu4/9pNsjH/4Os/VvS9IrH7IOQ=="
+            "version": "0.171.0",
+            "resolved": "https://registry.npmjs.org/three/-/three-0.171.0.tgz",
+            "integrity": "sha512-Y/lAXPaKZPcEdkKjh0JOAHVv8OOnv/NDJqm0wjfCzyQmfKxV7zvkwsnBgPBKTzJHToSOhRGQAGbPJObT59B/PQ=="
         },
         "node_modules/@aics/web-3d-viewer": {
-            "version": "2.10.3",
-            "resolved": "https://registry.npmjs.org/@aics/web-3d-viewer/-/web-3d-viewer-2.10.3.tgz",
-            "integrity": "sha512-9RbW3H2UI/jaVj7RjvsJJCjh4dOSJGt9apKSESrqW4tW6uwFSvZiadyxfQp8m/GyCyN5IKNkm8wwQIjjtzS/4g==",
+            "version": "2.10.4",
+            "resolved": "https://registry.npmjs.org/@aics/web-3d-viewer/-/web-3d-viewer-2.10.4.tgz",
+            "integrity": "sha512-lN7qHBQeLD5+VbNGci4dRw1wdbvZH0qivuk3diw28QG68ZTEMmSttbpl7fNmi7hdatZhs7m2UCjlUdUJ+I3YLw==",
             "dependencies": {
-                "@aics/volume-viewer": "^3.12.2",
+                "@aics/volume-viewer": "^3.12.3",
                 "@ant-design/icons": "^5.2.5",
                 "@fortawesome/fontawesome-svg-core": "^6.5.2",
                 "@fortawesome/free-solid-svg-icons": "^6.5.2",
@@ -157,9 +157,9 @@
             }
         },
         "node_modules/@aics/web-3d-viewer/node_modules/@ant-design/icons": {
-            "version": "5.5.1",
-            "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-5.5.1.tgz",
-            "integrity": "sha512-0UrM02MA2iDIgvLatWrj6YTCYe0F/cwXvVE0E2SqGrL7PZireQwgEKTKBisWpZyal5eXZLvuM98kju6YtYne8w==",
+            "version": "5.5.2",
+            "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-5.5.2.tgz",
+            "integrity": "sha512-xc53rjVBl9v2BqFxUjZGti/RfdDeA8/6KYglmInM2PNqSXc/WfuGDTifJI/ZsokJK0aeKvOIbXc9y2g8ILAhEA==",
             "dependencies": {
                 "@ant-design/colors": "^7.0.0",
                 "@ant-design/icons-svg": "^4.4.0",
@@ -3404,30 +3404,30 @@
             "license": "Apache-2.0"
         },
         "node_modules/@fortawesome/fontawesome-common-types": {
-            "version": "6.6.0",
-            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.6.0.tgz",
-            "integrity": "sha512-xyX0X9mc0kyz9plIyryrRbl7ngsA9jz77mCZJsUkLl+ZKs0KWObgaEBoSgQiYWAsSmjz/yjl0F++Got0Mdp4Rw==",
+            "version": "6.7.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz",
+            "integrity": "sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==",
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/@fortawesome/fontawesome-svg-core": {
-            "version": "6.6.0",
-            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.6.0.tgz",
-            "integrity": "sha512-KHwPkCk6oRT4HADE7smhfsKudt9N/9lm6EJ5BVg0tD1yPA5hht837fB87F8pn15D8JfTqQOjhKTktwmLMiD7Kg==",
+            "version": "6.7.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
+            "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
             "dependencies": {
-                "@fortawesome/fontawesome-common-types": "6.6.0"
+                "@fortawesome/fontawesome-common-types": "6.7.2"
             },
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/@fortawesome/free-solid-svg-icons": {
-            "version": "6.6.0",
-            "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.6.0.tgz",
-            "integrity": "sha512-IYv/2skhEDFc2WGUcqvFJkeK39Q+HyPf5GHUrT/l2pKbtgEIv1al1TKd6qStR5OIwQdN1GZP54ci3y4mroJWjA==",
+            "version": "6.7.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.7.2.tgz",
+            "integrity": "sha512-GsBrnOzU8uj0LECDfD5zomZJIjrPhIlWU82AHwa2s40FKH+kcxQaBvBo3Z4TxyZHIyX8XTDxsyA33/Vx9eFuQA==",
             "dependencies": {
-                "@fortawesome/fontawesome-common-types": "6.6.0"
+                "@fortawesome/fontawesome-common-types": "6.7.2"
             },
             "engines": {
                 "node": ">=6"
@@ -3958,9 +3958,9 @@
             }
         },
         "node_modules/@remix-run/router": {
-            "version": "1.20.0",
-            "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.20.0.tgz",
-            "integrity": "sha512-mUnk8rPJBI9loFDZ+YzPGdeniYK+FTmRD1TMCz7ev2SNIozyKKpnGgsxO34u6Z4z/t0ITuu7voi/AshfsGsgFg==",
+            "version": "1.21.0",
+            "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.21.0.tgz",
+            "integrity": "sha512-xfSkCAchbdG5PnbrKqFWwia4Bi61nH+wm8wLEqfHDyp7Y3dZzgqS2itV8i4gAq9pC2HsTpwyBC6Ds8VHZ96JlA==",
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -14089,11 +14089,11 @@
             }
         },
         "node_modules/react-router": {
-            "version": "6.27.0",
-            "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.27.0.tgz",
-            "integrity": "sha512-YA+HGZXz4jaAkVoYBE98VQl+nVzI+cVI2Oj/06F5ZM+0u3TgedN9Y9kmMRo2mnkSK2nCpNQn0DVob4HCsY/WLw==",
+            "version": "6.28.0",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.28.0.tgz",
+            "integrity": "sha512-HrYdIFqdrnhDw0PqG/AKjAqEqM7AvxCz0DQ4h2W8k6nqmc5uRBYDag0SBxx9iYz5G8gnuNVLzUe13wl9eAsXXg==",
             "dependencies": {
-                "@remix-run/router": "1.20.0"
+                "@remix-run/router": "1.21.0"
             },
             "engines": {
                 "node": ">=14.0.0"
@@ -14103,12 +14103,12 @@
             }
         },
         "node_modules/react-router-dom": {
-            "version": "6.27.0",
-            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.27.0.tgz",
-            "integrity": "sha512-+bvtFWMC0DgAFrfKXKG9Fc+BcXWRUO1aJIihbB79xaeq0v5UzfvnM5houGUm1Y461WVRcgAQ+Clh5rdb1eCx4g==",
+            "version": "6.28.0",
+            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.28.0.tgz",
+            "integrity": "sha512-kQ7Unsl5YdyOltsPGl31zOjLrDv+m2VcIEcIHqYYD3Lp0UppLjrzcfJqDJwXxFw3TH/yvapbnUvPlAj7Kx5nbg==",
             "dependencies": {
-                "@remix-run/router": "1.20.0",
-                "react-router": "6.27.0"
+                "@remix-run/router": "1.21.0",
+                "react-router": "6.28.0"
             },
             "engines": {
                 "node": ">=14.0.0"

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     },
     "dependencies": {
         "@aics/browsing-context-messaging": "~1.1",
-        "@aics/web-3d-viewer": "^2.10.3",
+        "@aics/web-3d-viewer": "^2.10.4",
         "@ant-design/icons": "^4.2.2",
         "antd": "^5.17.4",
         "axios": "^1.7.7",


### PR DESCRIPTION
Closes #223, volumes are blown out on certain volumes.

This change bumps web-3d-viewer to 2.10.4!

![image](https://github.com/user-attachments/assets/d59c3dd0-f421-407e-8961-8755816c1b04)

