### PR TITLE
feat: Load Vol-E props from CSV columns

### DIFF
--- a/src/components/CellViewer/index.tsx
+++ b/src/components/CellViewer/index.tsx
@@ -19,7 +19,7 @@ const CellViewer: React.FunctionComponent<VolumeViewerProps> = (props) => {
 
     return (
         <div className={styles.cellViewerContainer} style={CONTAINER_STYLE}>
-            <ViewerStateProvider>
+            <ViewerStateProvider viewerSettings={props.viewerSettings}>
                 <ImageViewerApp
                     cellId={props.cellId}
                     imageUrl={props.baseUrl + props.cellPath}
@@ -32,6 +32,7 @@ const CellViewer: React.FunctionComponent<VolumeViewerProps> = (props) => {
                     metadata={props.metadata}
                     appHeight="100%"
                     canvasMargin="0 0 0 0"
+                    {...props.appProps}
                 />
             </ViewerStateProvider>
         </div>

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -16,6 +16,7 @@ export const FOV_VOLUME_VIEWER_PATH = "fovVolumeviewerPath";
 export const THUMBNAIL_PATH = "thumbnailPath";
 export const VOLUME_VIEWER_PATH = "volumeviewerPath";
 export const TRANSFORM = "transform";
+export const VOLE_PARAMS = "voleUrlParams";
 
 export type FILE_INFO_KEY =
     | typeof CELL_ID_KEY

--- a/src/containers/Cfe/selectors.ts
+++ b/src/containers/Cfe/selectors.ts
@@ -15,7 +15,7 @@ import {
     formatDownloadOfIndividualFile,
 } from "../../state/util";
 
-import { ViewerChannelSettings } from "@aics/vole-app";
+import { AppProps, ViewerChannelSettings, ViewerState } from "@aics/vole-app";
 import { getMeasuredFeaturesDefs, getViewerChannelSettings } from "../../state/metadata/selectors";
 import { GROUP_BY_KEY } from "../../constants";
 
@@ -33,6 +33,8 @@ export interface VolumeViewerProps {
     };
     metadata?: { [key: string]: string | number | null };
     onControlPanelToggle?(collapsed: boolean): void;
+    appProps?: Partial<AppProps>;
+    viewerSettings?: Partial<ViewerState>;
 }
 
 function formatFeatureValue(featureValue: number | null, featureDef: MeasuredFeatureDef): string {
@@ -142,6 +144,8 @@ export const getPropsForVolumeViewer = createSelector(
             transform: alignActive ? fileInfo.transform : undefined,
             metadata: cellMetadata.metadata,
             viewerChannelSettings,
+            appProps: fileInfo.voleUrlParams?.args,
+            viewerSettings: fileInfo.voleUrlParams?.viewerSettings,
         };
     }
 );

--- a/src/state/metadata/types.ts
+++ b/src/state/metadata/types.ts
@@ -1,3 +1,5 @@
+import { AppProps, ViewerChannelSettings, ViewerState } from "@aics/vole-app";
+
 import {
     CELL_ID_KEY,
     FOV_ID_KEY,
@@ -6,11 +8,11 @@ import {
     GROUP_BY_KEY,
     THUMBNAIL_PATH,
     TRANSFORM,
+    VOLE_PARAMS,
     VOLUME_VIEWER_PATH,
 } from "../../constants";
 import { Megaset } from "../image-dataset/types";
 import { Album } from "../types";
-import { ViewerChannelSettings } from "@aics/vole-app";
 
 // FROM THE DATABASE TYPINGS
 
@@ -26,6 +28,8 @@ export interface FileInfo {
         rotation: [number, number, number];
     };
     [GROUP_BY_KEY]?: string;
+    [VOLE_PARAMS]?: { args: Partial<AppProps>; viewerSettings: Partial<ViewerState> };
+
     index?: number; // added to the data after it's loaded for fast lookup into other array
 }
 


### PR DESCRIPTION
Problem
=======
Closes #237, "additional VolE parameters per image."

When CFE loads data via a CSV, users now have the option to include Vol-E parameters as a column. This allows for more complex behavior, like having multiple sources per URL or jumping to a specific timestamp.

NOTE: This PR will fail static checking until I can merge and release changes in Vol-E (https://github.com/allen-cell-animated/vole-app/pull/444).

Solution
========
- Updated import for Vol-E to include the URL parsing logic.
- If present, the `Link Path` column will be parsed as optional props for Vol-E (`AppProps` and `ViewerState`). When the volume is opened, these props will be passed to Vol-E.
- Included parsed app props and viewer settings in `FileInfo`.

## Type of change
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Checkout and install branch locally.
2. Open http://localhost:9002/?dataset=csv&csvUrl=http://dev-aics-dtp-001.int.allencell.org/users/peyton.lee/test-data/cfe-example-2.csv

Screenshots (optional):
-----------------------
Show-n-tell images/animations here

Keyfiles (delete if not relevant):
-----------------------
1. main file/entry point
3. other important file

Thanks for contributing!
