### PR TITLE
fix: Fixed bug where metadata was overwritten by parsed Vol-E params

### DIFF
--- a/src/containers/Cfe/selectors.ts
+++ b/src/containers/Cfe/selectors.ts
@@ -33,7 +33,7 @@ export interface VolumeViewerProps {
         translation: [number, number, number];
         rotation: [number, number, number];
     };
-    metadata?: AppProps["metadata"] | (AppProps["metadata"] | undefined)[];
+    metadata?: AppProps["metadata"];
     onControlPanelToggle?(collapsed: boolean): void;
     appProps?: Partial<AppProps>;
     viewerSettings?: Partial<ViewerState>;

--- a/src/containers/Cfe/selectors.ts
+++ b/src/containers/Cfe/selectors.ts
@@ -1,5 +1,4 @@
-import { AppProps, ViewerChannelSettings, ViewerState } from "@aics/vole-app";
-import type { MetadataRecord } from "@aics/vole-app/type-declarations/aics-image-viewer/shared/types";
+import type { AppProps, ViewerChannelSettings, ViewerState } from "@aics/vole-app";
 import { isEmpty } from "lodash";
 import { createSelector } from "reselect";
 
@@ -21,6 +20,7 @@ import {
 import { getMeasuredFeaturesDefs, getViewerChannelSettings } from "../../state/metadata/selectors";
 import { GROUP_BY_KEY } from "../../constants";
 
+// TODO: Should VolumeViewerProps be replaced with AppProps?
 export interface VolumeViewerProps {
     cellId: string;
     baseUrl: string;
@@ -33,7 +33,7 @@ export interface VolumeViewerProps {
         translation: [number, number, number];
         rotation: [number, number, number];
     };
-    metadata?: MetadataRecord | (MetadataRecord | undefined)[];
+    metadata?: AppProps["metadata"] | (AppProps["metadata"] | undefined)[];
     onControlPanelToggle?(collapsed: boolean): void;
     appProps?: Partial<AppProps>;
     viewerSettings?: Partial<ViewerState>;
@@ -78,9 +78,9 @@ const getCellMetadata = createSelector(
 );
 
 const combineVoleMetadata = (
-    voleMetadata: VolumeViewerProps["metadata"],
+    voleMetadata: AppProps["metadata"],
     cellMetadata: { [key: string]: number | string | null }
-): VolumeViewerProps["metadata"] => {
+): AppProps["metadata"] => {
     if (Array.isArray(voleMetadata)) {
         return voleMetadata.map((metadata) => ({
             ...cellMetadata,

--- a/src/containers/Cfe/selectors.ts
+++ b/src/containers/Cfe/selectors.ts
@@ -1,5 +1,8 @@
+import { AppProps, ViewerChannelSettings, ViewerState } from "@aics/vole-app";
+import type { MetadataRecord } from "@aics/vole-app/type-declarations/aics-image-viewer/shared/types";
 import { isEmpty } from "lodash";
 import { createSelector } from "reselect";
+
 import { MeasuredFeatureDef } from "../../state/metadata/types";
 import {
     getAlignActive,
@@ -15,7 +18,6 @@ import {
     formatDownloadOfIndividualFile,
 } from "../../state/util";
 
-import { AppProps, ViewerChannelSettings, ViewerState } from "@aics/vole-app";
 import { getMeasuredFeaturesDefs, getViewerChannelSettings } from "../../state/metadata/selectors";
 import { GROUP_BY_KEY } from "../../constants";
 
@@ -31,7 +33,7 @@ export interface VolumeViewerProps {
         translation: [number, number, number];
         rotation: [number, number, number];
     };
-    metadata?: { [key: string]: string | number | null };
+    metadata?: MetadataRecord | (MetadataRecord | undefined)[];
     onControlPanelToggle?(collapsed: boolean): void;
     appProps?: Partial<AppProps>;
     viewerSettings?: Partial<ViewerState>;
@@ -74,6 +76,23 @@ const getCellMetadata = createSelector(
         return { metadata };
     }
 );
+
+const combineVoleMetadata = (
+    voleMetadata: VolumeViewerProps["metadata"],
+    cellMetadata: { [key: string]: number | string | null }
+): VolumeViewerProps["metadata"] => {
+    if (Array.isArray(voleMetadata)) {
+        return voleMetadata.map((metadata) => ({
+            ...cellMetadata,
+            ...metadata,
+        }));
+    } else {
+        return {
+            ...cellMetadata,
+            ...voleMetadata,
+        };
+    }
+};
 
 export const getPropsForVolumeViewer = createSelector(
     [
@@ -134,6 +153,18 @@ export const getPropsForVolumeViewer = createSelector(
         if (dataRoot !== "" && !dataRoot.endsWith("/")) {
             dataRoot = dataRoot + "/";
         }
+
+        // If metadata is being passed in via the voleUrlParams, combine with
+        // the existing metadata. Handles a bug where the returned Vol-E
+        // metadata was `[undefined]` and overwrote existing metadata.
+        let voleProps = fileInfo.voleUrlParams?.args;
+        if (voleProps && voleProps.metadata) {
+            voleProps = {
+                ...voleProps,
+                metadata: combineVoleMetadata(voleProps.metadata, cellMetadata.metadata),
+            };
+        }
+
         return {
             cellId: cellId,
             baseUrl: dataRoot,
@@ -144,7 +175,7 @@ export const getPropsForVolumeViewer = createSelector(
             transform: alignActive ? fileInfo.transform : undefined,
             metadata: cellMetadata.metadata,
             viewerChannelSettings,
-            appProps: fileInfo.voleUrlParams?.args,
+            appProps: voleProps,
             viewerSettings: fileInfo.voleUrlParams?.viewerSettings,
         };
     }


### PR DESCRIPTION
Problem
=======
Closes #272, "Metadata does not appear in Vol-E view."

When the `url` parameter is defined in the Vol-E URL column of a dataset, the URL parsing logic returns an array containing `undefined` for each URL included, which overwrote the existing feature metadata.

I resolved this bug by adding a method to combine existing metadata with returned Vol-E metadata instead.

*Estimated review size: small, 5-10 minutes*

Solution
========
- Combined existing metadata with Vol-E metadata when Vol-E has app props parsed from the CSV column.

## Type of change
* Bug fix (non-breaking change which fixes an issue)


Steps to Verify:
----------------
1. Open PR preview: https://allen-cell-animated.github.io/cell-feature-explorer/pr-preview/pr-280/?cellSelectedFor3D=15252&colorBy=Gene&dataset=csv&csvUrl=https%253A%252F%252Fvast-files.int.allencell.org%252Frep_learn%252FMF%252FOV%252Ffeatures_subset_data_voxel%252Fres%252Fembeddings_val_sub_structure.csv
2. Navigate to the 3D view and click on the metadata tab. The metadata will appear.

Screenshots (optional):
-----------------------
<img width="586" height="817" alt="image" src="https://github.com/user-attachments/assets/c66e27ad-d091-4803-9332-5c6d2dc6a311" />

