### PR TITLE
Hide popover thumbnail when not loaded

### DIFF
--- a/src/components/PopoverCard/index.tsx
+++ b/src/components/PopoverCard/index.tsx
@@ -13,16 +13,34 @@ export interface PopoverCardProps {
 }
 
 const PopoverCard: React.FC<PopoverCardProps> = (props) => {
-    const image = props.src ? (
-        <img alt="thumbnail of microscopy image" src={props.src} />
-    ) : (
-        <div className={styles.placeholderContainer}>
-            <PictureOutlined />
-        </div>
+    const [loadedImageSrc, setLoadedImageSrc] = React.useState("");
+    const onImageLoad = React.useCallback(
+        (e: React.SyntheticEvent<HTMLImageElement>) => setLoadedImageSrc(e.currentTarget.src),
+        []
+    );
+    const imageIsLoaded = props.src === loadedImageSrc;
+
+    const cover = (
+        <>
+            {props.src && (
+                <img
+                    alt="thumbnail of microscopy image"
+                    src={props.src}
+                    onLoad={onImageLoad}
+                    style={imageIsLoaded ? {} : { display: "none" }}
+                />
+            )}
+            <div
+                className={styles.placeholderContainer}
+                style={imageIsLoaded ? { display: "none" } : {}}
+            >
+                <PictureOutlined />
+            </div>
+        </>
     );
 
     return (
-        <Card className={styles.container} cover={image}>
+        <Card className={styles.container} cover={cover}>
             <Meta description={props.description} title={props.title} />
         </Card>
     );

--- a/src/components/PopoverCard/index.tsx
+++ b/src/components/PopoverCard/index.tsx
@@ -40,7 +40,7 @@ const PopoverCard: React.FC<PopoverCardProps> = (props) => {
     );
 
     return (
-        <Card className={styles.container} cover={cover}>
+        <Card className={styles.container} cover={cover} variant="borderless">
             <Meta description={props.description} title={props.title} />
         </Card>
     );

--- a/src/components/PopoverCard/index.tsx
+++ b/src/components/PopoverCard/index.tsx
@@ -13,12 +13,12 @@ export interface PopoverCardProps {
 }
 
 const PopoverCard: React.FC<PopoverCardProps> = (props) => {
-    const [loadedImageSrc, setLoadedImageSrc] = React.useState("");
+    const [loadedImageSrc, setLoadedImageSrc] = React.useState<string | undefined>(undefined);
     const onImageLoad = React.useCallback(
         (e: React.SyntheticEvent<HTMLImageElement>) => setLoadedImageSrc(e.currentTarget.src),
         []
     );
-    const imageIsLoaded = props.src === loadedImageSrc;
+    const imageIsLoaded = typeof props.src === "string" && props.src === loadedImageSrc;
 
     const cover = (
         <>

--- a/src/components/PopoverCard/style.css
+++ b/src/components/PopoverCard/style.css
@@ -10,7 +10,7 @@ div.placeholder-container.placeholder-container {
     justify-content: center;
     height: 80px;
     width: 80px;
-    background-color: var(--dimgray);
+    background-color: black;
     font-size: 36px;
 }
 

--- a/src/components/PopoverCard/style.css
+++ b/src/components/PopoverCard/style.css
@@ -8,7 +8,7 @@ div.placeholder-container.placeholder-container {
     display: flex;
     align-items: center;
     justify-content: center;
-    height: 55px;
+    height: 80px;
     width: 80px;
     background-color: var(--dimgray);
     font-size: 36px;

--- a/src/components/PopoverCard/style.css
+++ b/src/components/PopoverCard/style.css
@@ -1,19 +1,31 @@
-.container {
-    width: 80px;
-}
+:global(#thumbnail-popover) {
+    box-shadow: 0 2px 8px black;
+    padding: 0;
+    border-radius: 0;
+    border: 1px solid var(--white);
 
-/* Increase specificity to override Ant Design styles */
-div.placeholder-container.placeholder-container {
-    /* Format the placeholder to be centered */
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    height: 80px;
-    width: 80px;
-    background-color: black;
-    font-size: 36px;
-}
+    & :global(.ant-card),
+    :global(.ant-popover-inner-content) {
+        border-radius: 0;
+        padding: 0;
+    }
 
-.container :global(.ant-card-body) {
-    padding: 2px;
+    .container {
+        width: 80px;
+    }
+
+    div.placeholder-container {
+        /* Format the placeholder to be centered */
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        height: 80px;
+        width: 80px;
+        background-color: black;
+        font-size: 36px;
+    }
+
+    .container :global(.ant-card-body) {
+        padding: 2px;
+    }
 }

--- a/src/components/PopoverCard/style.css
+++ b/src/components/PopoverCard/style.css
@@ -25,6 +25,10 @@
         font-size: 36px;
     }
 
+    :global(.ant-card-cover) > * {
+        border-radius: 0;
+    }
+
     .container :global(.ant-card-body) {
         padding: 2px;
     }

--- a/src/components/PopoverCard/style.css
+++ b/src/components/PopoverCard/style.css
@@ -23,6 +23,10 @@
         width: 80px;
         background-color: black;
         font-size: 36px;
+
+        svg {
+            color: var(--dimgray);
+        }
     }
 
     :global(.ant-card-cover) > * {

--- a/src/containers/MainPlotContainer/index.tsx
+++ b/src/containers/MainPlotContainer/index.tsx
@@ -279,7 +279,7 @@ class MainPlotContainer extends React.Component<MainPlotContainerProps, MainPlot
         const popover = this.renderPopover();
 
         return (
-            <React.Fragment>
+            <>
                 <MouseFollower
                     ref={this.popoverContainer}
                     pageX={mousePosition.pageX}
@@ -290,11 +290,7 @@ class MainPlotContainer extends React.Component<MainPlotContainerProps, MainPlot
                         content={popover}
                         open={!!popover}
                         getPopupContainer={() => this.popoverContainer.current || document.body}
-                        {...{
-                            // props not in ant.d component, but do exist
-                            // needed to style this component since it's out of the DOM structure
-                            id: "thumbnail-popover",
-                        }}
+                        id="thumbnail-popover"
                     />
                 </MouseFollower>
                 <div
@@ -345,7 +341,7 @@ class MainPlotContainer extends React.Component<MainPlotContainerProps, MainPlot
                         yAxisRange={yAxisRange}
                     />
                 </div>
-            </React.Fragment>
+            </>
         );
     }
 }

--- a/src/containers/MainPlotContainer/style.css
+++ b/src/containers/MainPlotContainer/style.css
@@ -30,16 +30,3 @@
     /*override plotly svg styling*/
     fill: white !important;
 }
-
-:global(#thumbnail-popover) {
-    box-shadow: 0 2px 8px black;
-    padding: 0;
-    border-radius: 0;
-    border: 1px solid var(--white);
-
-    & :global(.ant-card),
-    :global(.ant-popover-inner-content) {
-        border-radius: 0;
-        padding: 0;
-    }
-}


### PR DESCRIPTION
Review time: small (<10min)

Resolves #282: popover thumbnail shows a placeholder until the image loads, preventing thumbnails from previously hovered points from persisting alongside a different point's title and metadata.

Also, while I was here, I consolidated and cleaned up some styling on the popover, including fixing a bug that caused the white border around the thumbnail to jitter in and out on displays with non-integer scaling (150% e.g.)
