### PR TITLE
fix: Fix bug where thumbnails would be overridden by auto-generated Zarr thumbnails

### DIFF
--- a/src/util/thumbnails.ts
+++ b/src/util/thumbnails.ts
@@ -50,7 +50,9 @@ export function useThumbnail(src: string, fileInfo: FileInfo): string {
                 }
             }
         };
-        tryGenerateThumbnailAsync();
+        if (!src && (volumeviewerPath || fovVolumeviewerPath)) {
+            tryGenerateThumbnailAsync();
+        }
     }, [src, volumeviewerPath, fovVolumeviewerPath]);
 
     return imageSrc;

--- a/src/util/thumbnails.ts
+++ b/src/util/thumbnails.ts
@@ -50,7 +50,7 @@ export function useThumbnail(src: string, fileInfo: FileInfo): string {
                 }
             }
         };
-        if (!src && (volumeviewerPath || fovVolumeviewerPath)) {
+        if (!src || src.endsWith(".zarr")) {
             tryGenerateThumbnailAsync();
         }
     }, [src, volumeviewerPath, fovVolumeviewerPath]);


### PR DESCRIPTION

Problem
=======
Closes #292, "Auto-generated thumbnails override user-provided thumbnails."

*Estimated review size: tiny, 2 minutes*

Solution
========
- Changed auto thumbnail generation to only run when image sources are not defined or are Zarrs that can't be directly rendered.

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Open current bugged build. The thumbnails in the galllery view will be overridden by greyscale images. https://cfe.allencell.org/?cellSelectedFor3D=6268&colorBy=structure&dataset=csv&csvUrl=https%253A%252F%252Fvast-files.int.allencell.org%252Frep_learn%252Forganelle_verse%252Foutput%252Fcell_eval%252Fcell_trained_3dmask_native%252Fembeddings_cells_batchcorr.csv&plotByOnX=umap_2&plotByOnY=umap_1&groupBy=structure
2. Open the fixed preview build. https://allen-cell-animated.github.io/cell-feature-explorer/pr-preview/pr-293/?cellSelectedFor3D=6268&colorBy=structure&dataset=csv&csvUrl=https%253A%252F%252Fvast-files.int.allencell.org%252Frep_learn%252Forganelle_verse%252Foutput%252Fcell_eval%252Fcell_trained_3dmask_native%252Fembeddings_cells_batchcorr.csv&plotByOnX=umap_2&plotByOnY=umap_1&groupBy=structure



